### PR TITLE
Only prepend #/definitions/ if value doesn't start with #/ in $ref

### DIFF
--- a/lib/swagger/blocks.rb
+++ b/lib/swagger/blocks.rb
@@ -233,7 +233,7 @@ module Swagger
           elsif is_swagger_2_0? && value.is_a?(Hash)
             result[key] = {}
             value.each_pair {|k, v| result[key][k] = (v.respond_to?(:as_json) ? v.as_json : v) }
-          elsif is_swagger_2_0? && key.to_s.eql?('$ref') && (value.to_s !~ %r{^#/definitions/})
+          elsif is_swagger_2_0? && key.to_s.eql?('$ref') && (value.to_s !~ %r{^#/})
             result[key] = "#/definitions/#{value}"
           else
             result[key] = value


### PR DESCRIPTION
This allows #/parameters/ to work