### PR TITLE
Cleaner way to write keys

### DIFF
--- a/lib/swagger/blocks.rb
+++ b/lib/swagger/blocks.rb
@@ -217,7 +217,11 @@ module Swagger
         instance = new
         instance.name = options[:name] if options[:name]
         instance.version = options[:version]
-        instance.instance_eval(&block)
+        ret = instance.instance_eval(&block)
+        # create keys if the block returns a hash
+        if ret.is_a?(Hash)
+          ret.each {|k,v| instance.key(k,v)}
+        end
         instance
       end
 
@@ -251,7 +255,12 @@ module Swagger
       def key(key, value)
         self.data[key] = value
       end
-
+      
+      # To allow write keys in any place in a more clean way
+      def keys=(kvs)
+        kvs.each {|k,v| key(k,v)}
+      end
+      
       def version
         return @version if instance_variable_defined?('@version') && @version
         if data.has_key?(:swagger) && data[:swagger] == '2.0'


### PR DESCRIPTION
Two minor changes to allow a more clean way to write the keys.

The first allow you to just return a hash and it will be considered keys:
```ruby
      parameter do
        {
            :name => :limit,
            :in => :query,
            :description => 'maximum number of results to return',
            :required => false,
            :type => :integer,
            :format => :int32,
        }
      end
```

The second allow you to write the keys in any place in a more clean way:
```ruby
swagger_path '/stores/{store_id}/products' do
    operation :get do
      self.keys = {
          :summary => 'Return all products',
          :description => 'Returns all products from from the system that the user has access to',
          :operationId => 'findProducts',
          :tags => ['products'],
      }

      parameter do
      # and so on
```

Why assignment? Just to use multiline hash without any parenthesis!