### PR TITLE
Support class autoreloading in Rails >= 3.2 dev env

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,15 +255,17 @@ class ApidocsController < ActionController::Base
   end
 
   # A list of all classes that have swagger_* declarations.
-  SWAGGERED_CLASSES = [
-    PetsController,
-    Pet,
-    ErrorModel,
-    self,
-  ].freeze
+  def swaggered_classes
+    [
+      PetsController,
+      Pet,
+      ErrorModel,
+      self.class
+    ]
+  end
 
   def index
-    render json: Swagger::Blocks.build_root_json(SWAGGERED_CLASSES)
+    render json: Swagger::Blocks.build_root_json(swaggered_classes)
   end
 end
 ```
@@ -271,7 +273,7 @@ end
 The special part of this controller is this line:
 
 ```Ruby
-render json: Swagger::Blocks.build_root_json(SWAGGERED_CLASSES)
+render json: Swagger::Blocks.build_root_json(swaggered_classes)
 ```
 
 That is the only line necessary to build the full [root Swagger object](https://github.com/swagger-api/swagger-spec/blob/master/versions/2.0.md#schema) JSON and all definitions underneath it. You simply pass in a list of all the "swaggered" classes in your app.
@@ -367,7 +369,7 @@ These inline keys can be used on any block, not just `parameter` blocks.
 If you are not serving the JSON directly and need to write it to a file for some reason, you can easily use `build_root_json` for that as well:
 
 ```Ruby
-swagger_data = Swagger::Blocks.build_root_json(SWAGGERED_CLASSES)
+swagger_data = Swagger::Blocks.build_root_json(swaggered_classes)
 File.open('swagger.json', 'w') { |file| file.write(swagger_data.to_json) }
 ```
 
@@ -377,7 +379,7 @@ If certain attributes must be customized on-the-fly, you can merge a hash contai
 
 ```Ruby
 def build_and_override_root_json(overrides = {})
-  Swagger::Blocks.build_root_json(SWAGGERED_CLASSES).merge(overrides)
+  Swagger::Blocks.build_root_json(swaggered_classes).merge(overrides)
 end
 ```
 

--- a/README_v1_2.md
+++ b/README_v1_2.md
@@ -111,18 +111,20 @@ class ApidocsController < ActionController::Base
   end
 
   # A list of all classes that have swagger_* declarations.
-  SWAGGERED_CLASSES = [
-    PetsController,
-    Pets,
-    self,
-  ].freeze
+  def swaggered_classes 
+    [
+      PetsController,
+      Pets,
+      self.class
+    ]
+  end
 
   def index
-    render json: Swagger::Blocks.build_root_json(SWAGGERED_CLASSES)
+    render json: Swagger::Blocks.build_root_json(swaggered_classes)
   end
 
   def show
-    render json: Swagger::Blocks.build_api_json(params[:id], SWAGGERED_CLASSES)
+    render json: Swagger::Blocks.build_api_json(params[:id], swaggered_classes)
   end
 end
 
@@ -131,11 +133,11 @@ end
 The special part of this controller are these lines:
 
 ```Ruby
-render json: Swagger::Blocks.build_root_json(SWAGGERED_CLASSES)
+render json: Swagger::Blocks.build_root_json(swaggered_classes)
 ```
 
 ```Ruby
-render json: Swagger::Blocks.build_api_json(params[:id], SWAGGERED_CLASSES)
+render json: Swagger::Blocks.build_api_json(params[:id], swaggered_classes)
 ```
 
 Those are the only lines necessary to build the root Swagger [Resource Listing](https://github.com/wordnik/swagger-spec/blob/master/versions/1.2.md#51-resource-listing) JSON and the JSON for each Swagger [API Declaration](https://github.com/wordnik/swagger-spec/blob/master/versions/1.2.md#52-api-declaration). You simply pass in a list of all the "swaggered" classes in your app.


### PR DESCRIPTION
In my Rails 4.2 environment example code from README doesn't work with [Rails reloading constants](http://guides.rubyonrails.org/autoloading_and_reloading_constants.html).

Without this fix old declarations are cached until development server is restarted.
This happens because classes in `SWAGGERED_CLASSES` array are not reloaded.

This behaviour can be easily tested in Rails console:
```
irb(main):001:0> x = ApplicationController
=> ApplicationController
irb(main):002:0> reload!
Reloading...
=> true
irb(main):003:0> x == ApplicationController
=> true
# change ApplicationController class by adding a blank line
irb(main):004:0> reload!
Reloading...
=> true
irb(main):005:0> x == ApplicationController
=> false
```

I'm not sure if there's a better way to force reload.