### PR TITLE
unescape paths

### DIFF
--- a/lib/swagger/blocks.rb
+++ b/lib/swagger/blocks.rb
@@ -1,4 +1,5 @@
 require 'json'
+require 'uri'
 require 'swagger/blocks/version'
 
 module Swagger
@@ -146,7 +147,7 @@ module Swagger
       # v2.0: Defines a Swagger Path Item object
       # https://github.com/swagger-api/swagger-spec/blob/master/versions/2.0.md#path-item-object
       def swagger_path(path, &block)
-        path = path.to_sym
+        path = URI.unescape(path.to_s).to_sym
 
         # TODO enforce that path name begins with a '/'
         #   (or x- , but need to research Vendor Extensions first)


### PR DESCRIPTION
Wanted to see your opinion on this.

In a scenario where we use path helpers to generate a swagger path:

```ruby
swagger_path some_resource_path("{some_id}") do
   ...
end
```

The desire is for the swagger param interpolation to work as expected. However, a path helper is likely to escape the `{` and `}` characters, resulting in `%7Bsome_id%7D` in the swagger json.

Do you think the fix for this fits rightly in the swagger json generation (e.g. this commit), or is this is a swagger ui (or equivalent downstream client) responsibility?