### PR TITLE
Allow objects inside items.

### DIFF
--- a/lib/swagger/blocks.rb
+++ b/lib/swagger/blocks.rb
@@ -692,7 +692,13 @@ module Swagger
 
     # v1.2:
     # v2.0:
-    class ItemsNode < Node; end
+    class ItemsNode < Node
+      def property(name, inline_keys = nil, &block)
+        self.data[:properties] ||= Swagger::Blocks::PropertiesNode.new
+        self.data[:properties].version = version
+        self.data[:properties].property(name, inline_keys, &block)
+      end
+    end
 
     # v1.2: http://goo.gl/PvwUXj#524-parameter-object
     # v2.0: https://github.com/swagger-api/swagger-spec/blob/master/versions/2.0.md#parameter-object

--- a/spec/lib/swagger_v2_api_declaration.json
+++ b/spec/lib/swagger_v2_api_declaration.json
@@ -251,6 +251,20 @@
                   "type": "string"
                 }
               }
+            },
+            "arrayOfObjects": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "age": {
+                    "type": "integer"
+                  }
+                }
+              }
             }
           }
         }

--- a/spec/lib/swagger_v2_blocks_spec.rb
+++ b/spec/lib/swagger_v2_blocks_spec.rb
@@ -219,6 +219,18 @@ class PetV2
             key :type, :string
           end
         end
+        property :arrayOfObjects do
+          key :type, :array
+          items do
+            key :type, :object
+            property :name do
+              key :type, :string
+            end
+            property :age do
+              key :type, :integer
+            end
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
Hello, I was trying to specify objects inside items but swagger-blocks does not allow it. The following example shows what I want to do:
```
responses:
        # Response code
        200:
          description: Successful response
          # A schema describing your response object.
          # Use JSON Schema format
          schema:
            title: ArrayOfPersons
            type: array
            items:
              title: Person
              type: object
              properties:
                name:
                  type: string
                single:
                  type: boolean
                nestedObject:
                  type: object
                  required:
                  - name
                  properties:
                    name:
                      type: string
```
 I did what you told me in your last comment on issue 42 and now works in my fork.