### PR TITLE
add PathNode#parameter

### DIFF
--- a/lib/swagger/blocks.rb
+++ b/lib/swagger/blocks.rb
@@ -499,6 +499,11 @@ module Swagger
         raise ArgumentError.new("#{name} not in #{OPERATION_TYPES}") if !OPERATION_TYPES.include?(op)
         self.data[op] = Swagger::Blocks::OperationNode.call(version: version, inline_keys: inline_keys, &block)
       end
+
+      def parameter(inline_keys = nil, &block)
+        self.data[:parameters] ||= []
+        self.data[:parameters] << Swagger::Blocks::ParameterNode.call(version: version, inline_keys: inline_keys, &block)
+      end
     end
 
     # v1.2: http://goo.gl/PvwUXj#523-operation-object

--- a/spec/lib/swagger_v2_api_declaration.json
+++ b/spec/lib/swagger_v2_api_declaration.json
@@ -133,6 +133,16 @@
       }
     },
     "/pets/{id}": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "description": "ID of pet",
+          "required": true,
+          "type": "integer",
+          "format": "int64"
+        }
+      ],
       "get": {
         "description": "Returns a user based on a single ID, if the user does not have access to the pet",
         "operationId": "findPetById",
@@ -141,16 +151,6 @@
           "application/xml",
           "text/xml",
           "text/html"
-        ],
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "description": "ID of pet to fetch",
-            "required": true,
-            "type": "integer",
-            "format": "int64"
-          }
         ],
         "responses": {
           "200": {
@@ -181,16 +181,6 @@
       "delete": {
         "description": "deletes a single pet based on the ID supplied",
         "operationId": "deletePet",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "description": "ID of pet to delete",
-            "required": true,
-            "type": "integer",
-            "format": "int64"
-          }
-        ],
         "responses": {
           "204": {
             "description": "pet deleted"

--- a/spec/lib/swagger_v2_blocks_spec.rb
+++ b/spec/lib/swagger_v2_blocks_spec.rb
@@ -121,6 +121,14 @@ class PetControllerV2
   end
 
   swagger_path '/pets/{id}' do
+    parameter do
+      key :name, :id
+      key :in, :path
+      key :description, 'ID of pet'
+      key :required, true
+      key :type, :integer
+      key :format, :int64
+    end
     operation :get do
       key :description, 'Returns a user based on a single ID, if the user does not have access to the pet'
       key :operationId, 'findPetById'
@@ -130,14 +138,6 @@ class PetControllerV2
         'text/xml',
         'text/html',
       ]
-      parameter do
-        key :name, :id
-        key :in, :path
-        key :description, 'ID of pet to fetch'
-        key :required, true
-        key :type, :integer
-        key :format, :int64
-      end
       response 200 do
         key :description, 'pet response'
         schema do
@@ -158,14 +158,6 @@ class PetControllerV2
     operation :delete do
       key :description, 'deletes a single pet based on the ID supplied'
       key :operationId, 'deletePet'
-      parameter do
-        key :name, :id
-        key :in, :path
-        key :description, 'ID of pet to delete'
-        key :required, true
-        key :type, :integer
-        key :format, :int64
-      end
       response 204 do
         key :description, 'pet deleted'
       end


### PR DESCRIPTION
Per swagger v2 specification, parameters should be specifiable at the
path level. This adds the helper method to do so, and updates the
example swagger specification (and generated json) so that the ID
parameter for the path `/pets/{id}` is specified at the path level.

Closes #49.