### PR TITLE
Allow root node to be extended

### DIFF
--- a/lib/swagger/blocks.rb
+++ b/lib/swagger/blocks.rb
@@ -114,7 +114,11 @@ module Swagger
       # v2.0: Defines a Swagger Object
       # v2.0: https://github.com/swagger-api/swagger-spec/blob/master/versions/2.0.md#swagger-object
       def swagger_root(inline_keys = nil, &block)
-        @swagger_root_node ||= Swagger::Blocks::RootNode.call(inline_keys: inline_keys, &block)
+        if instance_variable_defined?(:@swagger_root_node)
+          @swagger_root_node.instance_eval(&block)
+        else
+          @swagger_root_node = Swagger::Blocks::RootNode.call(inline_keys: inline_keys, &block)
+        end
       end
 
       # v1.2: Defines a Swagger API Declaration.

--- a/spec/lib/swagger_v2_blocks_spec.rb
+++ b/spec/lib/swagger_v2_blocks_spec.rb
@@ -26,6 +26,15 @@ class PetControllerV2
     key :schemes, ['http']
     key :consumes, ['application/json']
     key :produces, ['application/json']
+    tag name: 'pet' do
+      key :description, 'Pets operations'
+      externalDocs description: 'Find more info here' do
+        key :url, 'https://swagger.io'
+      end
+    end
+  end
+
+  swagger_root do
     security_definition :api_key, type: :apiKey do
       key :name, :api_key
       key :in, :header
@@ -36,12 +45,6 @@ class PetControllerV2
       key :flow, :implicit
       scopes 'write:pets' => 'modify pets in your account' do
         key 'read:pets', 'read your pets'
-      end
-    end
-    tag name: 'pet' do
-      key :description, 'Pets operations'
-      externalDocs description: 'Find more info here' do
-        key :url, 'https://swagger.io'
       end
     end
   end


### PR DESCRIPTION
If the root_node method is called multiple times, extend the existing
root node instead of overwriting it.
