### PR TITLE
Add feature for Swagger 2.0 parameter references

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,6 +331,31 @@ The `key` block simply takes the value you give and puts it directly into the fi
   key :foo, {some_complex: {nested_object: true}}
 ```
 
+#### Parameter referencing
+
+It is possible to reference parameters rather than explicitly define them in every action in which they are used.
+
+To define a reusable parameter, declare it within `swagger_root`
+To reference the parameter, call it within a `swagger_path` or `operation` node
+
+```ruby
+swagger_root do
+  key :swagger, '2.0'
+  # ...
+  parameter :species do
+    key :name, :species
+    key :description, 'Species of this pet'
+  end
+end
+
+swagger_path '/pets/' do
+  operation :post do
+    parameter :species
+    # ...
+  end
+end
+```
+
 #### Inline keys
 
 It is possible to omit numerous `key` calls using inline hash keys on any block.
@@ -382,6 +407,8 @@ end
 ```
 
 #### Reducing boilerplate
+
+To create reusable parameters, please see [parameter referencing](#parameter-referencing)
 
 Most APIs have some common responses for 401s, 404s, etc. Rather than declaring these responses over and over, you can create a reusable module.
 

--- a/lib/swagger/blocks.rb
+++ b/lib/swagger/blocks.rb
@@ -501,6 +501,8 @@ module Swagger
       end
 
       def parameter(inline_keys = nil, &block)
+        inline_keys = {'$ref' => "#/parameters/#{inline_keys}"} if inline_keys.is_a?(Symbol)
+
         self.data[:parameters] ||= []
         self.data[:parameters] << Swagger::Blocks::ParameterNode.call(version: version, inline_keys: inline_keys, &block)
       end
@@ -509,8 +511,9 @@ module Swagger
     # v1.2: http://goo.gl/PvwUXj#523-operation-object
     # v2.0: https://github.com/swagger-api/swagger-spec/blob/master/versions/2.0.md#operation-object
     class OperationNode < Node
-
       def parameter(inline_keys = nil, &block)
+        inline_keys = {'$ref' => "#/parameters/#{inline_keys}"} if inline_keys.is_a?(Symbol)
+
         self.data[:parameters] ||= []
         self.data[:parameters] << Swagger::Blocks::ParameterNode.call(version: version, inline_keys: inline_keys, &block)
       end

--- a/spec/lib/swagger_v2_api_declaration.json
+++ b/spec/lib/swagger_v2_api_declaration.json
@@ -49,6 +49,14 @@
       }
     }
   ],
+  "parameters": {
+    "species": {
+      "name": "species",
+      "in": "body",
+      "description": "Species of this pet",
+      "type": "string"
+    }
+  },
   "paths": {
     "/pets": {
       "get": {
@@ -114,6 +122,9 @@
             "schema": {
               "$ref": "#/definitions/PetInput"
             }
+          },
+          {
+            "$ref": "#/parameters/species"
           }
         ],
         "responses": {
@@ -177,6 +188,41 @@
             ]
           }
         ]
+      },
+      "put": {
+        "description": "Update a pet in the store.",
+        "operationId": "updatePet",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "pet",
+            "in": "body",
+            "description": "Pet to update in the store",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/PetInput"
+            }
+          },
+          {
+            "$ref": "#/parameters/species"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "pet response",
+            "schema": {
+              "$ref": "#/parameters/Pet"
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "schema": {
+              "$ref": "http://example.com/schema.json#/definitions/ErrorModel"
+            }
+          }
+        }
       },
       "delete": {
         "description": "deletes a single pet based on the ID supplied",

--- a/spec/lib/swagger_v2_blocks_spec.rb
+++ b/spec/lib/swagger_v2_blocks_spec.rb
@@ -44,6 +44,12 @@ class PetControllerV2
         key :url, 'https://swagger.io'
       end
     end
+    parameter :species do
+      key :name, :species
+      key :in, :body
+      key :description, 'Species of this pet'
+      key :type, :string
+    end
   end
 
   swagger_path '/pets' do
@@ -105,6 +111,7 @@ class PetControllerV2
           key :'$ref', :PetInput
         end
       end
+      parameter :species
       response 200 do
         key :description, 'pet response'
         schema do
@@ -128,6 +135,37 @@ class PetControllerV2
       key :required, true
       key :type, :integer
       key :format, :int64
+    end
+    operation :put do
+      key :description, 'Update a pet in the store.'
+      key :operationId, 'updatePet'
+      key :produces, [
+        'application/json'
+      ]
+      parameter do
+        key :name, :pet
+        key :in, :body
+        key :description, 'Pet to update in the store'
+        key :required, true
+        schema do
+          key :'$ref', :PetInput
+        end
+      end
+
+      parameter :species
+
+      response 200 do
+        key :description, 'pet response'
+        schema do
+          # Wrong form here, but checks that #/ strings are not transformed.
+          key :'$ref', '#/parameters/Pet'
+        end
+      end
+      response :default, description: 'unexpected error' do
+        schema do
+          key :'$ref', 'http://example.com/schema.json#/definitions/ErrorModel'
+        end
+      end
     end
     operation :get do
       key :description, 'Returns a user based on a single ID, if the user does not have access to the pet'
@@ -269,7 +307,6 @@ describe 'Swagger::Blocks v2' do
     end
     it 'is idempotent' do
       swaggered_classes = [PetControllerV2, PetV2, ErrorModelV2]
-      actual = JSON.parse(Swagger::Blocks.build_root_json(swaggered_classes).to_json)
       actual = JSON.parse(Swagger::Blocks.build_root_json(swaggered_classes).to_json)
       data = JSON.parse(RESOURCE_LISTING_JSON_V2)
       expect(actual).to eq(data)


### PR DESCRIPTION
@dkniffin was also a big contributor to this PR

### Why?
* Addresses #64 
* Allows for Swagger 2.0 parameter reuse

### What Changed?
* The `parameter` method in `OperationNode` and `PathNode` can now use symbols as references to root level `parameters`.

* Updated tests for referenced params

* Updated README