### PR TITLE
Improve gem summary and description

### DIFF
--- a/swagger-blocks.gemspec
+++ b/swagger-blocks.gemspec
@@ -8,8 +8,8 @@ Gem::Specification.new do |spec|
   spec.version       = Swagger::Blocks::VERSION
   spec.authors       = ['Mike Fotinakis']
   spec.email         = ['mike@fotinakis.com']
-  spec.summary       = %q{Define and serve live-updating Swagger JSON for Ruby apps.}
-  spec.description   = %q{}
+  spec.summary       = 'Define and serve live-updating OpenAPI (fka Swagger) JSON for Ruby apps.'
+  spec.description   = spec.summary
   spec.homepage      = 'https://github.com/fotinakis/swagger-blocks'
   spec.license       = 'MIT'
 


### PR DESCRIPTION
Adding OpenAPI to gem summary will helps people to find this gem on rubygems.org by openapi keyword.