### PR TITLE
WIP: Add basic support for openapi

### DIFF
--- a/lib/swagger/blocks.rb
+++ b/lib/swagger/blocks.rb
@@ -17,6 +17,7 @@ module Swagger
       autoload :ContentNode, 'swagger/blocks/nodes/content_node'
       autoload :ExampleNode, 'swagger/blocks/nodes/example_node'
       autoload :ExternalDocsNode, 'swagger/blocks/nodes/external_docs_node'
+      autoload :FlowNode, 'swagger/blocks/nodes/flow_node'
       autoload :HeaderNode, 'swagger/blocks/nodes/header_node'
       autoload :InfoNode, 'swagger/blocks/nodes/info_node'
       autoload :ItemsNode, 'swagger/blocks/nodes/items_node'

--- a/lib/swagger/blocks.rb
+++ b/lib/swagger/blocks.rb
@@ -39,6 +39,7 @@ module Swagger
       autoload :ServerNode, 'swagger/blocks/nodes/server_node'
       autoload :TagNode, 'swagger/blocks/nodes/tag_node'
       autoload :ValueNode, 'swagger/blocks/nodes/value_node'
+      autoload :VariableNode, 'swagger/blocks/nodes/variable_node'
       autoload :XmlNode, 'swagger/blocks/nodes/xml_node'
     end
   end

--- a/lib/swagger/blocks.rb
+++ b/lib/swagger/blocks.rb
@@ -9,6 +9,9 @@ module Swagger
 
     module Nodes
       autoload :AllOfNode, 'swagger/blocks/nodes/all_of_node'
+      autoload :CallbackNode, 'swagger/blocks/nodes/callback_node'
+      autoload :CallbackDestinationNode, 'swagger/blocks/nodes/callback_destination_node'
+      autoload :CallbackMethodNode, 'swagger/blocks/nodes/callback_method_node'
       autoload :ComponentNode, 'swagger/blocks/nodes/component_node'
       autoload :ContactNode, 'swagger/blocks/nodes/contact_node'
       autoload :ContentNode, 'swagger/blocks/nodes/content_node'

--- a/lib/swagger/blocks.rb
+++ b/lib/swagger/blocks.rb
@@ -37,6 +37,7 @@ module Swagger
       autoload :SecuritySchemeNode, 'swagger/blocks/nodes/security_scheme_node'
       autoload :ServerNode, 'swagger/blocks/nodes/server_node'
       autoload :TagNode, 'swagger/blocks/nodes/tag_node'
+      autoload :ValueNode, 'swagger/blocks/nodes/value_node'
       autoload :XmlNode, 'swagger/blocks/nodes/xml_node'
     end
   end

--- a/lib/swagger/blocks.rb
+++ b/lib/swagger/blocks.rb
@@ -21,6 +21,8 @@ module Swagger
       autoload :InfoNode, 'swagger/blocks/nodes/info_node'
       autoload :ItemsNode, 'swagger/blocks/nodes/items_node'
       autoload :LicenseNode, 'swagger/blocks/nodes/license_node'
+      autoload :LinkNode, 'swagger/blocks/nodes/link_node'
+      autoload :LinkParameterNode, 'swagger/blocks/nodes/link_parameter_node'
       autoload :OperationNode, 'swagger/blocks/nodes/operation_node'
       autoload :ParameterNode, 'swagger/blocks/nodes/parameter_node'
       autoload :PathNode, 'swagger/blocks/nodes/path_node'

--- a/lib/swagger/blocks.rb
+++ b/lib/swagger/blocks.rb
@@ -42,6 +42,7 @@ module Swagger
       autoload :ValueNode, 'swagger/blocks/nodes/value_node'
       autoload :VariableNode, 'swagger/blocks/nodes/variable_node'
       autoload :XmlNode, 'swagger/blocks/nodes/xml_node'
+      autoload :VendorExtensionNode, 'swagger/blocks/nodes/vendor_extension_node'
     end
   end
 end

--- a/lib/swagger/blocks.rb
+++ b/lib/swagger/blocks.rb
@@ -24,6 +24,7 @@ module Swagger
       autoload :LicenseNode, 'swagger/blocks/nodes/license_node'
       autoload :LinkNode, 'swagger/blocks/nodes/link_node'
       autoload :LinkParameterNode, 'swagger/blocks/nodes/link_parameter_node'
+      autoload :OneOfNode, 'swagger/blocks/nodes/one_of_node'
       autoload :OperationNode, 'swagger/blocks/nodes/operation_node'
       autoload :ParameterNode, 'swagger/blocks/nodes/parameter_node'
       autoload :PathNode, 'swagger/blocks/nodes/path_node'

--- a/lib/swagger/blocks.rb
+++ b/lib/swagger/blocks.rb
@@ -9,7 +9,9 @@ module Swagger
 
     module Nodes
       autoload :AllOfNode, 'swagger/blocks/nodes/all_of_node'
+      autoload :ComponentNode, 'swagger/blocks/nodes/component_node'
       autoload :ContactNode, 'swagger/blocks/nodes/contact_node'
+      autoload :ContentNode, 'swagger/blocks/nodes/content_node'
       autoload :ExampleNode, 'swagger/blocks/nodes/example_node'
       autoload :ExternalDocsNode, 'swagger/blocks/nodes/external_docs_node'
       autoload :HeaderNode, 'swagger/blocks/nodes/header_node'
@@ -21,12 +23,14 @@ module Swagger
       autoload :PathNode, 'swagger/blocks/nodes/path_node'
       autoload :PropertiesNode, 'swagger/blocks/nodes/properties_node'
       autoload :PropertyNode, 'swagger/blocks/nodes/property_node'
+      autoload :RequestBodyNode, 'swagger/blocks/nodes/request_body_node'
       autoload :ResponseNode, 'swagger/blocks/nodes/response_node'
       autoload :RootNode, 'swagger/blocks/nodes/root_node'
       autoload :SchemaNode, 'swagger/blocks/nodes/schema_node'
       autoload :ScopesNode, 'swagger/blocks/nodes/scopes_node'
       autoload :SecurityRequirementNode, 'swagger/blocks/nodes/security_requirement_node'
       autoload :SecuritySchemeNode, 'swagger/blocks/nodes/security_scheme_node'
+      autoload :ServerNode, 'swagger/blocks/nodes/server_node'
       autoload :TagNode, 'swagger/blocks/nodes/tag_node'
       autoload :XmlNode, 'swagger/blocks/nodes/xml_node'
     end

--- a/lib/swagger/blocks/class_methods.rb
+++ b/lib/swagger/blocks/class_methods.rb
@@ -9,6 +9,14 @@ module Swagger
         @swagger_root_node ||= Swagger::Blocks::Nodes::RootNode.call(inline_keys: inline_keys, &block)
       end
 
+      def version
+        if @swagger_root_node && @swagger_root_node.data[:info]&.version == '3.0.0'
+          '3.0.0'
+        else
+          '2.0'
+        end
+      end
+
       # v2.0: Defines a Swagger Path Item object
       # https://github.com/swagger-api/swagger-spec/blob/master/versions/2.0.md#path-item-object
       def swagger_path(path, &block)
@@ -25,7 +33,7 @@ module Swagger
           path_node.instance_eval(&block)
         else
           # First time we've seen this path
-          @swagger_path_node_map[path] = Swagger::Blocks::Nodes::PathNode.call(version: '2.0', &block)
+          @swagger_path_node_map[path] = Swagger::Blocks::Nodes::PathNode.call(version: version, &block)
         end
       end
 
@@ -41,8 +49,12 @@ module Swagger
           schema_node.instance_eval(&block)
         else
           # First time we've seen this schema_node
-          @swagger_schema_node_map[name] = Swagger::Blocks::Nodes::SchemaNode.call(version: '2.0', inline_keys: inline_keys, &block)
+          @swagger_schema_node_map[name] = Swagger::Blocks::Nodes::SchemaNode.call(version: version, inline_keys: inline_keys, &block)
         end
+      end
+
+      def swagger_component(inline_keys = nil, &block)
+        @swagger_components_node ||= Swagger::Blocks::Nodes::ComponentNode.call(version: version, inline_keys: inline_keys, &block)
       end
 
       def _swagger_nodes
@@ -52,12 +64,14 @@ module Swagger
         @swagger_schema_node_map ||= nil
         @swagger_api_root_node_map ||= {}
         @swagger_models_node ||= nil
+        @swagger_components_node ||= nil
 
         data = {root_node: @swagger_root_node}
         data[:path_node_map] = @swagger_path_node_map
         data[:schema_node_map] = @swagger_schema_node_map
         data[:api_node_map] = @swagger_api_root_node_map
         data[:models_node] = @swagger_models_node
+        data[:component_node] = @swagger_components_node
         data
       end
     end

--- a/lib/swagger/blocks/class_methods.rb
+++ b/lib/swagger/blocks/class_methods.rb
@@ -12,6 +12,8 @@ module Swagger
       def version
         if defined?(@swagger_root_node) && @swagger_root_node.data[:info] && @swagger_root_node.data[:info].version == '3.0.0'
           '3.0.0'
+        elsif defined?(VERSION)
+          VERSION
         else
           '2.0'
         end

--- a/lib/swagger/blocks/class_methods.rb
+++ b/lib/swagger/blocks/class_methods.rb
@@ -10,7 +10,7 @@ module Swagger
       end
 
       def version
-        if @swagger_root_node && @swagger_root_node.data[:info]&.version == '3.0.0'
+        if defined?(@swagger_root_node) && @swagger_root_node.data[:info] && @swagger_root_node.data[:info].version == '3.0.0'
           '3.0.0'
         else
           '2.0'

--- a/lib/swagger/blocks/class_methods.rb
+++ b/lib/swagger/blocks/class_methods.rb
@@ -12,8 +12,6 @@ module Swagger
       def version
         if defined?(@swagger_root_node) && @swagger_root_node.data[:info] && @swagger_root_node.data[:info].version == '3.0.0'
           '3.0.0'
-        elsif defined?(VERSION)
-          VERSION
         else
           '2.0'
         end

--- a/lib/swagger/blocks/class_methods.rb
+++ b/lib/swagger/blocks/class_methods.rb
@@ -54,7 +54,7 @@ module Swagger
       end
 
       def swagger_component(inline_keys = nil, &block)
-        @swagger_components_node ||= Swagger::Blocks::Nodes::ComponentNode.call(version: version, inline_keys: inline_keys, &block)
+        @swagger_components_node ||= Swagger::Blocks::Nodes::ComponentNode.call(version: '3.0.0', inline_keys: inline_keys, &block)
       end
 
       def _swagger_nodes

--- a/lib/swagger/blocks/internal_helpers.rb
+++ b/lib/swagger/blocks/internal_helpers.rb
@@ -10,6 +10,8 @@ module Swagger
 
         path_node_map = {}
         schema_node_map = {}
+        component_node = nil
+
         swaggered_classes.each do |swaggered_class|
           next unless swaggered_class.respond_to?(:_swagger_nodes, true)
           swagger_nodes = swaggered_class.send(:_swagger_nodes)
@@ -23,11 +25,23 @@ module Swagger
           if swagger_nodes[:schema_node_map]
             schema_node_map.merge!(swagger_nodes[:schema_node_map])
           end
+          if swagger_nodes[:component_node]
+            if component_node
+              component_node.data[:schemas].merge!(swagger_nodes[:component_node].data[:schemas])
+            else
+              component_node = swagger_nodes[:component_node]
+            end
+          end
         end
+
         data = {root_node: self.limit_root_node(root_nodes)}
+
         if data[:root_node].is_swagger_2_0?
           data[:path_nodes] = path_node_map
           data[:schema_nodes] = schema_node_map
+        elsif data[:root_node].is_openapi_3_0?
+          data[:path_nodes] = path_node_map
+          data[:component_node] = component_node
         else
           data[:api_node_map] = api_node_map
           data[:models_nodes] = models_nodes

--- a/lib/swagger/blocks/internal_helpers.rb
+++ b/lib/swagger/blocks/internal_helpers.rb
@@ -27,7 +27,13 @@ module Swagger
           end
           if swagger_nodes[:component_node]
             if component_node
-              component_node.data[:schemas].merge!(swagger_nodes[:component_node].data[:schemas])
+              merge_components(component_node, swagger_nodes, :examples)
+              merge_components(component_node, swagger_nodes, :links)
+              merge_components(component_node, swagger_nodes, :parameters)
+              merge_components(component_node, swagger_nodes, :requestBodies)
+              merge_components(component_node, swagger_nodes, :responses)
+              merge_components(component_node, swagger_nodes, :schemas)
+              merge_components(component_node, swagger_nodes, :securitySchemes)
             else
               component_node = swagger_nodes[:component_node]
             end
@@ -47,6 +53,11 @@ module Swagger
           data[:models_nodes] = models_nodes
         end
         data
+      end
+
+      def self.merge_components(component_node, swagger_nodes, key)
+        component_node.data[key] ||= {}
+        component_node.data[key].merge!(swagger_nodes[:component_node].data[key]) if swagger_nodes[:component_node].data[key]
       end
 
       # Make sure there is exactly one root_node and return it.

--- a/lib/swagger/blocks/node.rb
+++ b/lib/swagger/blocks/node.rb
@@ -29,6 +29,8 @@ module Swagger
             value.each_pair {|k, v| result[key][k] = (v.respond_to?(:as_json) ? v.as_json : v) }
           elsif is_swagger_2_0? && key.to_s.eql?('$ref') && (value.to_s !~ %r{^#/|https?://})
             result[key] = "#/definitions/#{value}"
+          elsif is_openapi_3_0? && key.to_s.eql?('$ref') && self.is_a?(Swagger::Blocks::Nodes::LinkNode) && (value.to_s !~ %r{^#/|https?://})
+            result[key] = "#/components/links/#{value}"
           elsif is_openapi_3_0? && key.to_s.eql?('$ref') && (value.to_s !~ %r{^#/|https?://})
             result[key] = "#/components/schemas/#{value}"
           else

--- a/lib/swagger/blocks/node.rb
+++ b/lib/swagger/blocks/node.rb
@@ -27,14 +27,18 @@ module Swagger
           elsif (is_swagger_2_0? || is_openapi_3_0?) && value.is_a?(Hash)
             result[key] = {}
             value.each_pair {|k, v| result[key][k] = (v.respond_to?(:as_json) ? v.as_json : v) }
-          elsif is_swagger_2_0? && key.to_s.eql?('$ref') && (value.to_s !~ %r{^#/|https?://})
-            result[key] = "#/definitions/#{value}"
           elsif is_openapi_3_0? && key.to_s.eql?('$ref') && self.is_a?(Swagger::Blocks::Nodes::LinkNode) && (value.to_s !~ %r{^#/|https?://})
             result[key] = "#/components/links/#{value}"
           elsif is_openapi_3_0? && key.to_s.eql?('$ref') && self.is_a?(Swagger::Blocks::Nodes::ExampleNode) && (value.to_s !~ %r{^#/|https?://})
             result[key] = "#/components/examples/#{value}"
+          elsif is_openapi_3_0? && key.to_s.eql?('$ref') && self.is_a?(Swagger::Blocks::Nodes::ParameterNode) && (value.to_s !~ %r{^#/|https?://})
+            result[key] = "#/components/parameters/#{value}"
+          elsif is_openapi_3_0? && key.to_s.eql?('$ref') && self.is_a?(Swagger::Blocks::Nodes::RequestBodyNode) && (value.to_s !~ %r{^#/|https?://})
+            result[key] = "#/components/requestBodies/#{value}"
           elsif is_openapi_3_0? && key.to_s.eql?('$ref') && (value.to_s !~ %r{^#/|https?://})
             result[key] = "#/components/schemas/#{value}"
+          elsif is_swagger_2_0? && key.to_s.eql?('$ref') && (value.to_s !~ %r{^#/|https?://})
+            result[key] = "#/definitions/#{value}"
           else
             result[key] = value
           end

--- a/lib/swagger/blocks/node.rb
+++ b/lib/swagger/blocks/node.rb
@@ -42,6 +42,8 @@ module Swagger
             result[key] = "#/components/parameters/#{value}"
           elsif version == VERSION_3 && ref?(key) && self.is_a?(Swagger::Blocks::Nodes::RequestBodyNode) && !static_ref?(value)
             result[key] = "#/components/requestBodies/#{value}"
+          elsif version == VERSION_3 && ref?(key) && self.is_a?(Swagger::Blocks::Nodes::ResponseNode) && !static_ref?(value)
+            result[key] = "#/components/responses/#{value}"
           elsif version == VERSION_3 && ref?(key) && !static_ref?(value)
             result[key] = "#/components/schemas/#{value}"
           else

--- a/lib/swagger/blocks/node.rb
+++ b/lib/swagger/blocks/node.rb
@@ -18,7 +18,7 @@ module Swagger
       end
 
       def as_json(options = {})
-        version = options.fetch(:version, '2.0')
+        version = options.fetch(:version, VERSION_2)
 
         result = {}
         self.data.each do |key, value|
@@ -85,17 +85,17 @@ module Swagger
 
       def version
         return @version if instance_variable_defined?('@version') && @version
-        return '2.0' if data.has_key?(:swagger) && data[:swagger] == '2.0'
-        return '3.0.0' if data.has_key?(:openapi) && data[:openapi] == '3.0.0'
-        raise DeclarationError, "You must specify swagger '2.0' or openapi '3.0.0'"
+        return VERSION_2 if data.has_key?(:swagger) && data[:swagger] == VERSION_2
+        return VERSION_3 if data.has_key?(:openapi) && data[:openapi] == VERSION_3
+        raise DeclarationError, "You must specify swagger '#{VERSION_2}' or openapi '#{VERSION_3}'"
       end
 
       def is_swagger_2_0?
-        version == '2.0'
+        version == VERSION_2
       end
 
       def is_openapi_3_0?
-        version == '3.0.0'
+        version == VERSION_3
       end
     end
   end

--- a/lib/swagger/blocks/node.rb
+++ b/lib/swagger/blocks/node.rb
@@ -4,6 +4,8 @@ module Swagger
     class Node
       attr_accessor :name
       attr_writer :version
+      VERSION_2 = '2.0'
+      VERSION_3 = '3.0.0'
 
       def self.call(options = {}, &block)
         # Create a new instance and evaluate the block into it.
@@ -15,30 +17,33 @@ module Swagger
         instance
       end
 
-      def as_json
-        result = {}
+      def as_json(options = {})
+        version = options.fetch(:version, '2.0')
 
+        result = {}
         self.data.each do |key, value|
           if value.is_a?(Node)
-            result[key] = value.as_json
+            result[key] = value.as_json(version: version)
           elsif value.is_a?(Array)
             result[key] = []
-            value.each { |v| result[key] << (v.respond_to?(:as_json) ? v.as_json : v) }
-          elsif (is_swagger_2_0? || is_openapi_3_0?) && value.is_a?(Hash)
+            value.each do |v|
+              result[key] << value_as_json(v, version)
+            end
+          elsif value.is_a?(Hash)
             result[key] = {}
-            value.each_pair {|k, v| result[key][k] = (v.respond_to?(:as_json) ? v.as_json : v) }
-          elsif is_openapi_3_0? && key.to_s.eql?('$ref') && self.is_a?(Swagger::Blocks::Nodes::LinkNode) && (value.to_s !~ %r{^#/|https?://})
-            result[key] = "#/components/links/#{value}"
-          elsif is_openapi_3_0? && key.to_s.eql?('$ref') && self.is_a?(Swagger::Blocks::Nodes::ExampleNode) && (value.to_s !~ %r{^#/|https?://})
-            result[key] = "#/components/examples/#{value}"
-          elsif is_openapi_3_0? && key.to_s.eql?('$ref') && self.is_a?(Swagger::Blocks::Nodes::ParameterNode) && (value.to_s !~ %r{^#/|https?://})
-            result[key] = "#/components/parameters/#{value}"
-          elsif is_openapi_3_0? && key.to_s.eql?('$ref') && self.is_a?(Swagger::Blocks::Nodes::RequestBodyNode) && (value.to_s !~ %r{^#/|https?://})
-            result[key] = "#/components/requestBodies/#{value}"
-          elsif is_openapi_3_0? && key.to_s.eql?('$ref') && (value.to_s !~ %r{^#/|https?://})
-            result[key] = "#/components/schemas/#{value}"
-          elsif is_swagger_2_0? && key.to_s.eql?('$ref') && (value.to_s !~ %r{^#/|https?://})
+            value.each_pair {|k, v| result[key][k] = value_as_json(v, version) }
+          elsif version == VERSION_2 && ref?(key) && !static_ref?(value)
             result[key] = "#/definitions/#{value}"
+          elsif version == VERSION_3 && ref?(key) && self.is_a?(Swagger::Blocks::Nodes::LinkNode) && !static_ref?(value)
+            result[key] = "#/components/links/#{value}"
+          elsif version == VERSION_3 && ref?(key) && self.is_a?(Swagger::Blocks::Nodes::ExampleNode) && !static_ref?(value)
+            result[key] = "#/components/examples/#{value}"
+          elsif version == VERSION_3 && ref?(key) && self.is_a?(Swagger::Blocks::Nodes::ParameterNode) && !static_ref?(value)
+            result[key] = "#/components/parameters/#{value}"
+          elsif version == VERSION_3 && ref?(key) && self.is_a?(Swagger::Blocks::Nodes::RequestBodyNode) && !static_ref?(value)
+            result[key] = "#/components/requestBodies/#{value}"
+          elsif version == VERSION_3 && ref?(key) && !static_ref?(value)
+            result[key] = "#/components/schemas/#{value}"
           else
             result[key] = value
           end
@@ -46,6 +51,22 @@ module Swagger
         return result if !name
         # If 'name' is given to this node, wrap the data with a root element with the given name.
         {name => result}
+      end
+
+      def ref?(key)
+        key.to_s.eql?('$ref')
+      end
+
+      def static_ref?(value)
+        value.to_s =~ %r{^#/|https?://}
+      end
+
+      def value_as_json(value, version)
+        if value.respond_to?(:as_json)
+           value.as_json(version: version)
+        else
+           value
+        end
       end
 
       def data

--- a/lib/swagger/blocks/node.rb
+++ b/lib/swagger/blocks/node.rb
@@ -31,6 +31,8 @@ module Swagger
             result[key] = "#/definitions/#{value}"
           elsif is_openapi_3_0? && key.to_s.eql?('$ref') && self.is_a?(Swagger::Blocks::Nodes::LinkNode) && (value.to_s !~ %r{^#/|https?://})
             result[key] = "#/components/links/#{value}"
+          elsif is_openapi_3_0? && key.to_s.eql?('$ref') && self.is_a?(Swagger::Blocks::Nodes::ExampleNode) && (value.to_s !~ %r{^#/|https?://})
+            result[key] = "#/components/examples/#{value}"
           elsif is_openapi_3_0? && key.to_s.eql?('$ref') && (value.to_s !~ %r{^#/|https?://})
             result[key] = "#/components/schemas/#{value}"
           else

--- a/lib/swagger/blocks/nodes/all_of_node.rb
+++ b/lib/swagger/blocks/nodes/all_of_node.rb
@@ -12,7 +12,7 @@ module Swagger
               r = []
               value.each { |v| r << (v.respond_to?(:as_json) ? v.as_json : v) }
               result << r
-            elsif is_swagger_2_0? && value.is_a?(Hash)
+            elsif (is_swagger_2_0? is_openapi_3_0?) && value.is_a?(Hash)
               r = {}
               value.each_pair {|k, v| r[k] = (v.respond_to?(:as_json) ? v.as_json : v) }
               result << r

--- a/lib/swagger/blocks/nodes/all_of_node.rb
+++ b/lib/swagger/blocks/nodes/all_of_node.rb
@@ -2,19 +2,20 @@ module Swagger
   module Blocks
     module Nodes
       class AllOfNode < Node
-        def as_json
+        def as_json(options = {})
+          version = options.fetch(:version, '2.0')
           result = []
 
           self.data.each do |value|
             if value.is_a?(Node)
-              result << value.as_json
+              result << value.as_json(version: version)
             elsif value.is_a?(Array)
               r = []
-              value.each { |v| r << (v.respond_to?(:as_json) ? v.as_json : v) }
+              value.each { |v| r << value_as_json(v, version) }
               result << r
             elsif (is_swagger_2_0? || is_openapi_3_0?) && value.is_a?(Hash)
               r = {}
-              value.each_pair {|k, v| r[k] = (v.respond_to?(:as_json) ? v.as_json : v) }
+              value.each_pair {|k, v| r[k] = value_as_json(v, version) }
               result << r
             else
               result = value

--- a/lib/swagger/blocks/nodes/all_of_node.rb
+++ b/lib/swagger/blocks/nodes/all_of_node.rb
@@ -12,7 +12,7 @@ module Swagger
               r = []
               value.each { |v| r << (v.respond_to?(:as_json) ? v.as_json : v) }
               result << r
-            elsif (is_swagger_2_0? is_openapi_3_0?) && value.is_a?(Hash)
+            elsif (is_swagger_2_0? || is_openapi_3_0?) && value.is_a?(Hash)
               r = {}
               value.each_pair {|k, v| r[k] = (v.respond_to?(:as_json) ? v.as_json : v) }
               result << r

--- a/lib/swagger/blocks/nodes/callback_destination_node.rb
+++ b/lib/swagger/blocks/nodes/callback_destination_node.rb
@@ -3,7 +3,6 @@ module Swagger
     module Nodes
       class CallbackDestinationNode < Node
         def method(method_name, inline_keys = nil, &block)
-          puts method_name.class
           self.data[method_name] = Swagger::Blocks::Nodes::CallbackMethodNode.call(version: version, inline_keys: inline_keys, &block)
         end
       end

--- a/lib/swagger/blocks/nodes/callback_destination_node.rb
+++ b/lib/swagger/blocks/nodes/callback_destination_node.rb
@@ -1,0 +1,12 @@
+module Swagger
+  module Blocks
+    module Nodes
+      class CallbackDestinationNode < Node
+        def method(method_name, inline_keys = nil, &block)
+          puts method_name.class
+          self.data[method_name] = Swagger::Blocks::Nodes::CallbackMethodNode.call(version: version, inline_keys: inline_keys, &block)
+        end
+      end
+    end
+  end
+end

--- a/lib/swagger/blocks/nodes/callback_method_node.rb
+++ b/lib/swagger/blocks/nodes/callback_method_node.rb
@@ -1,0 +1,16 @@
+module Swagger
+  module Blocks
+    module Nodes
+      class CallbackMethodNode < Node
+        def request_body(inline_keys = nil, &block)
+          self.data[:requestBody] = Swagger::Blocks::Nodes::RequestBodyNode.call(version: version, inline_keys: inline_keys, &block)
+        end
+
+        def response(resp, inline_keys = nil, &block)
+          self.data[:responses] ||= {}
+          self.data[:responses][resp] = Swagger::Blocks::Nodes::ResponseNode.call(version: version, inline_keys: inline_keys, &block)
+        end
+      end
+    end
+  end
+end

--- a/lib/swagger/blocks/nodes/callback_node.rb
+++ b/lib/swagger/blocks/nodes/callback_node.rb
@@ -1,0 +1,11 @@
+module Swagger
+  module Blocks
+    module Nodes
+      class CallbackNode < Node
+        def destination(address, inline_keys = nil, &block)
+          self.data[address] = Swagger::Blocks::Nodes::CallbackDestinationNode.call(version: version, inline_keys: inline_keys, &block)
+        end
+      end
+    end
+  end
+end

--- a/lib/swagger/blocks/nodes/component_node.rb
+++ b/lib/swagger/blocks/nodes/component_node.rb
@@ -19,6 +19,11 @@ module Swagger
           self.data[:links] ||= {}
           self.data[:links][name] = Swagger::Blocks::Nodes::LinkNode.call(version: version, inline_keys: inline_keys, &block)
         end
+
+        def example(name, inline_keys = nil, &block)
+          self.data[:examples] ||= {}
+          self.data[:examples][name] = Swagger::Blocks::Nodes::ExampleNode.call(version: version, inline_keys: inline_keys, &block)
+        end
       end
     end
   end

--- a/lib/swagger/blocks/nodes/component_node.rb
+++ b/lib/swagger/blocks/nodes/component_node.rb
@@ -39,6 +39,11 @@ module Swagger
           self.data[:requestBodies] ||= {}
           self.data[:requestBodies][name] = Swagger::Blocks::Nodes::RequestBodyNode.call(version: version, inline_keys: inline_keys, &block)
         end
+
+        def response(name, inline_keys = nil, &block)
+          self.data[:responses] ||= {}
+          self.data[:responses][name] = Swagger::Blocks::Nodes::ResponseNode.call(version: version, inline_keys: inline_keys, &block)
+        end
       end
     end
   end

--- a/lib/swagger/blocks/nodes/component_node.rb
+++ b/lib/swagger/blocks/nodes/component_node.rb
@@ -14,6 +14,11 @@ module Swagger
             self.data[:schemas][name] = Swagger::Blocks::Nodes::SchemaNode.call(version: '3.0.0', inline_keys: inline_keys, &block)
           end
         end
+
+        def link(name, inline_keys = nil, &block)
+          self.data[:links] ||= {}
+          self.data[:links][name] = Swagger::Blocks::Nodes::LinkNode.call(version: version, inline_keys: inline_keys, &block)
+        end
       end
     end
   end

--- a/lib/swagger/blocks/nodes/component_node.rb
+++ b/lib/swagger/blocks/nodes/component_node.rb
@@ -24,6 +24,11 @@ module Swagger
           self.data[:examples] ||= {}
           self.data[:examples][name] = Swagger::Blocks::Nodes::ExampleNode.call(version: version, inline_keys: inline_keys, &block)
         end
+
+        def security_scheme(name, inline_keys = nil, &block)
+          self.data[:securitySchemes] ||= {}
+          self.data[:securitySchemes][name] = Swagger::Blocks::Nodes::SecuritySchemeNode.call(version: version, inline_keys: inline_keys, &block)
+        end
       end
     end
   end

--- a/lib/swagger/blocks/nodes/component_node.rb
+++ b/lib/swagger/blocks/nodes/component_node.rb
@@ -29,6 +29,16 @@ module Swagger
           self.data[:securitySchemes] ||= {}
           self.data[:securitySchemes][name] = Swagger::Blocks::Nodes::SecuritySchemeNode.call(version: version, inline_keys: inline_keys, &block)
         end
+
+        def parameter(name, inline_keys = nil, &block)
+          self.data[:parameters] ||= {}
+          self.data[:parameters][name] = Swagger::Blocks::Nodes::ParameterNode.call(version: version, inline_keys: inline_keys, &block)
+        end
+
+        def request_body(name, inline_keys = nil, &block)
+          self.data[:requestBodies] ||= {}
+          self.data[:requestBodies][name] = Swagger::Blocks::Nodes::RequestBodyNode.call(version: version, inline_keys: inline_keys, &block)
+        end
       end
     end
   end

--- a/lib/swagger/blocks/nodes/component_node.rb
+++ b/lib/swagger/blocks/nodes/component_node.rb
@@ -1,0 +1,20 @@
+module Swagger
+  module Blocks
+    module Nodes
+      class ComponentNode < Node
+        def schema(name, inline_keys = nil, &block)
+          self.data[:schemas] ||= {}
+          schema_node = self.data[:schemas][name]
+
+          if schema_node
+            # Merge this schema_node declaration into the previous one
+            schema_node.instance_eval(&block)
+          else
+            # First time we've seen this schema_node
+            self.data[:schemas][name] = Swagger::Blocks::Nodes::SchemaNode.call(version: '3.0.0', inline_keys: inline_keys, &block)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/swagger/blocks/nodes/content_node.rb
+++ b/lib/swagger/blocks/nodes/content_node.rb
@@ -1,0 +1,11 @@
+module Swagger
+  module Blocks
+    module Nodes
+      class ContentNode < Node
+        def schema(inline_keys = nil, &block)
+          self.data[:schema] = Swagger::Blocks::Nodes::SchemaNode.call(version: version, inline_keys: inline_keys, &block)
+        end
+      end
+    end
+  end
+end

--- a/lib/swagger/blocks/nodes/content_node.rb
+++ b/lib/swagger/blocks/nodes/content_node.rb
@@ -6,9 +6,13 @@ module Swagger
           self.data[:schema] = Swagger::Blocks::Nodes::SchemaNode.call(version: version, inline_keys: inline_keys, &block)
         end
 
-        def example(name, inline_keys = nil, &block)
-          self.data[:examples] ||= {}
-          self.data[:examples][name] = Swagger::Blocks::Nodes::ExampleNode.call(version: version, inline_keys: inline_keys, &block)
+        def example(name = nil, inline_keys = nil, &block)
+          if name.nil?
+            self.data[:example] = Swagger::Blocks::Nodes::ExampleNode.call(version: version, inline_keys: inline_keys, &block)
+          else
+            self.data[:examples] ||= {}
+            self.data[:examples][name] = Swagger::Blocks::Nodes::ExampleNode.call(version: version, inline_keys: inline_keys, &block)
+          end
         end
       end
     end

--- a/lib/swagger/blocks/nodes/content_node.rb
+++ b/lib/swagger/blocks/nodes/content_node.rb
@@ -5,6 +5,11 @@ module Swagger
         def schema(inline_keys = nil, &block)
           self.data[:schema] = Swagger::Blocks::Nodes::SchemaNode.call(version: version, inline_keys: inline_keys, &block)
         end
+
+        def example(name, inline_keys = nil, &block)
+          self.data[:examples] ||= {}
+          self.data[:examples][name] = Swagger::Blocks::Nodes::ExampleNode.call(version: version, inline_keys: inline_keys, &block)
+        end
       end
     end
   end

--- a/lib/swagger/blocks/nodes/example_node.rb
+++ b/lib/swagger/blocks/nodes/example_node.rb
@@ -1,8 +1,10 @@
 module Swagger
   module Blocks
     module Nodes
-      # v2.0:
       class ExampleNode < Node
+        def value(inline_keys = nil, &block)
+          self.data[:value] = Swagger::Blocks::Nodes::ValueNode.call(version: version, inline_keys: inline_keys, &block)
+        end
       end
     end
   end

--- a/lib/swagger/blocks/nodes/flow_node.rb
+++ b/lib/swagger/blocks/nodes/flow_node.rb
@@ -1,0 +1,11 @@
+module Swagger
+  module Blocks
+    module Nodes
+      class FlowNode < Node
+        def scopes(inline_keys = nil, &block)
+          self.data[:scopes] = Swagger::Blocks::Nodes::ScopesNode.call(version: version, inline_keys: inline_keys, &block)
+        end
+      end
+    end
+  end
+end

--- a/lib/swagger/blocks/nodes/header_node.rb
+++ b/lib/swagger/blocks/nodes/header_node.rb
@@ -6,6 +6,10 @@ module Swagger
         def items(inline_keys = nil, &block)
           self.data[:items] = Swagger::Blocks::Nodes::ItemsNode.call(version: version, inline_keys: inline_keys, &block)
         end
+
+        def schema(inline_keys = nil, &block)
+          self.data[:schema] = Swagger::Blocks::Nodes::SchemaNode.call(version: version, inline_keys: inline_keys, &block)
+        end
       end
     end
   end

--- a/lib/swagger/blocks/nodes/items_node.rb
+++ b/lib/swagger/blocks/nodes/items_node.rb
@@ -8,7 +8,7 @@ module Swagger
           self.data[:properties].version = version
           self.data[:properties].property(name, inline_keys, &block)
         end
-        
+
         def items(inline_keys = nil, &block)
           self.data[:items] = Swagger::Blocks::Nodes::ItemsNode.call(version: version, inline_keys: inline_keys, &block)
         end

--- a/lib/swagger/blocks/nodes/link_node.rb
+++ b/lib/swagger/blocks/nodes/link_node.rb
@@ -1,0 +1,11 @@
+module Swagger
+  module Blocks
+    module Nodes
+      class LinkNode < Node
+        def parameters(inline_keys = nil, &block)
+          self.data[:parameters] ||= Swagger::Blocks::Nodes::LinkParameterNode.call(version: version, inline_keys: inline_keys, &block)
+        end
+      end
+    end
+  end
+end

--- a/lib/swagger/blocks/nodes/link_parameter_node.rb
+++ b/lib/swagger/blocks/nodes/link_parameter_node.rb
@@ -1,0 +1,8 @@
+module Swagger
+  module Blocks
+    module Nodes
+      class LinkParameterNode < Node
+      end
+    end
+  end
+end

--- a/lib/swagger/blocks/nodes/one_of_node.rb
+++ b/lib/swagger/blocks/nodes/one_of_node.rb
@@ -1,0 +1,8 @@
+module Swagger
+  module Blocks
+    module Nodes
+      class OneOfNode < Node
+      end
+    end
+  end
+end

--- a/lib/swagger/blocks/nodes/one_of_node.rb
+++ b/lib/swagger/blocks/nodes/one_of_node.rb
@@ -2,6 +2,9 @@ module Swagger
   module Blocks
     module Nodes
       class OneOfNode < Node
+        def items(inline_keys = nil, &block)
+          self.data[:items] = Swagger::Blocks::Nodes::ItemsNode.call(version: version, inline_keys: inline_keys, &block)
+        end
       end
     end
   end

--- a/lib/swagger/blocks/nodes/operation_node.rb
+++ b/lib/swagger/blocks/nodes/operation_node.rb
@@ -28,6 +28,11 @@ module Swagger
         def request_body(inline_keys = nil, &block)
           self.data[:requestBody] = Swagger::Blocks::Nodes::RequestBodyNode.call(version: version, inline_keys: inline_keys, &block)
         end
+
+        def callback(event_name, inline_keys = nil, &block)
+          self.data[:callbacks] ||= {}
+          self.data[:callbacks][event_name] = Swagger::Blocks::Nodes::CallbackNode.call(version: version, inline_keys: inline_keys, &block)
+        end
       end
     end
   end

--- a/lib/swagger/blocks/nodes/operation_node.rb
+++ b/lib/swagger/blocks/nodes/operation_node.rb
@@ -24,6 +24,10 @@ module Swagger
           self.data[:security] ||= []
           self.data[:security] << Swagger::Blocks::Nodes::SecurityRequirementNode.call(version: version, inline_keys: inline_keys, &block)
         end
+
+        def request_body(inline_keys = nil, &block)
+          self.data[:requestBody] = Swagger::Blocks::Nodes::RequestBodyNode.call(version: version, inline_keys: inline_keys, &block)
+        end
       end
     end
   end

--- a/lib/swagger/blocks/nodes/operation_node.rb
+++ b/lib/swagger/blocks/nodes/operation_node.rb
@@ -33,6 +33,12 @@ module Swagger
           self.data[:callbacks] ||= {}
           self.data[:callbacks][event_name] = Swagger::Blocks::Nodes::CallbackNode.call(version: version, inline_keys: inline_keys, &block)
         end
+
+        def server(inline_keys = nil, &block)
+          raise NotSupportedError unless is_openapi_3_0?
+          self.data[:servers] ||= []
+          self.data[:servers] << Swagger::Blocks::Nodes::ServerNode.call(version: version, inline_keys: inline_keys, &block)
+        end
       end
     end
   end

--- a/lib/swagger/blocks/nodes/parameter_node.rb
+++ b/lib/swagger/blocks/nodes/parameter_node.rb
@@ -10,6 +10,11 @@ module Swagger
         def items(inline_keys = nil, &block)
           self.data[:items] = Swagger::Blocks::Nodes::ItemsNode.call(version: version, inline_keys: inline_keys, &block)
         end
+
+        def example(name, inline_keys = nil, &block)
+          self.data[:examples] ||= {}
+          self.data[:examples][name] = Swagger::Blocks::Nodes::ExampleNode.call(version: version, inline_keys: inline_keys, &block)
+        end
       end
     end
   end

--- a/lib/swagger/blocks/nodes/path_node.rb
+++ b/lib/swagger/blocks/nodes/path_node.rb
@@ -18,6 +18,12 @@ module Swagger
           self.data[:parameters] ||= []
           self.data[:parameters] << Swagger::Blocks::Nodes::ParameterNode.call(version: version, inline_keys: inline_keys, &block)
         end
+
+        def server(inline_keys = nil, &block)
+          raise NotSupportedError unless is_openapi_3_0?
+          self.data[:servers] ||= []
+          self.data[:servers] << Swagger::Blocks::Nodes::ServerNode.call(version: version, inline_keys: inline_keys, &block)
+        end
       end
     end
   end

--- a/lib/swagger/blocks/nodes/property_node.rb
+++ b/lib/swagger/blocks/nodes/property_node.rb
@@ -11,6 +11,11 @@ module Swagger
           self.data[:properties].version = version
           self.data[:properties].property(name, inline_keys, &block)
         end
+
+        def one_of(&block)
+          self.data[:oneOf] ||= []
+          self.data[:oneOf] << Swagger::Blocks::Nodes::OneOfNode.call(version: version, &block)
+        end
       end
     end
   end

--- a/lib/swagger/blocks/nodes/request_body_node.rb
+++ b/lib/swagger/blocks/nodes/request_body_node.rb
@@ -1,0 +1,12 @@
+module Swagger
+  module Blocks
+    module Nodes
+      class RequestBodyNode < Node
+        def content(type, inline_keys = nil, &block)
+          self.data[:content] ||= {}
+          self.data[:content][type] = Swagger::Blocks::Nodes::ContentNode.call(version: version, inline_keys: inline_keys, &block)
+        end
+      end
+    end
+  end
+end

--- a/lib/swagger/blocks/nodes/response_node.rb
+++ b/lib/swagger/blocks/nodes/response_node.rb
@@ -18,10 +18,13 @@ module Swagger
           self.data[:content][type] = Swagger::Blocks::Nodes::ContentNode.call(version: version, inline_keys: inline_keys, &block)
         end
 
-        def example(exam, inline_keys = nil, &block)
-          # TODO validate 'exam' is as per spec
-          self.data[:examples] ||= {}
-          self.data[:examples][exam] = Swagger::Blocks::Nodes::ExampleNode.call(version: version, inline_keys: inline_keys, &block)
+        def example(name = nil, inline_keys = nil, &block)
+          if name.nil?
+            self.data[:example] = Swagger::Blocks::Nodes::ExampleNode.call(version: version, inline_keys: inline_keys, &block)
+          else
+            self.data[:examples] ||= {}
+            self.data[:examples][name] = Swagger::Blocks::Nodes::ExampleNode.call(version: version, inline_keys: inline_keys, &block)
+          end
         end
 
         def link(name, inline_keys = nil, &block)

--- a/lib/swagger/blocks/nodes/response_node.rb
+++ b/lib/swagger/blocks/nodes/response_node.rb
@@ -13,6 +13,11 @@ module Swagger
           self.data[:headers][head] = Swagger::Blocks::Nodes::HeaderNode.call(version: version, inline_keys: inline_keys, &block)
         end
 
+        def content(type, inline_keys = nil, &block)
+          self.data[:content] ||= {}
+          self.data[:content][type] = Swagger::Blocks::Nodes::ContentNode.call(version: version, inline_keys: inline_keys, &block)
+        end
+
         def example(exam, inline_keys = nil, &block)
           # TODO validate 'exam' is as per spec
           self.data[:examples] ||= {}

--- a/lib/swagger/blocks/nodes/response_node.rb
+++ b/lib/swagger/blocks/nodes/response_node.rb
@@ -23,6 +23,11 @@ module Swagger
           self.data[:examples] ||= {}
           self.data[:examples][exam] = Swagger::Blocks::Nodes::ExampleNode.call(version: version, inline_keys: inline_keys, &block)
         end
+
+        def link(name, inline_keys = nil, &block)
+          self.data[:links] ||= {}
+          self.data[:links][name] = Swagger::Blocks::Nodes::LinkNode.call(version: version, inline_keys: inline_keys, &block)
+        end
       end
     end
   end

--- a/lib/swagger/blocks/nodes/root_node.rb
+++ b/lib/swagger/blocks/nodes/root_node.rb
@@ -42,10 +42,16 @@ module Swagger
         end
 
         def tag(inline_keys = nil, &block)
-          raise NotSupportedError unless is_swagger_2_0?
+          raise NotSupportedError unless is_swagger_2_0? || is_openapi_3_0?
 
           self.data[:tags] ||= []
           self.data[:tags] << Swagger::Blocks::Nodes::TagNode.call(version: version, inline_keys: inline_keys, &block)
+        end
+
+        def server(inline_keys = nil, &block)
+          raise NotSupportedError unless is_openapi_3_0?
+          self.data[:servers] ||= []
+          self.data[:servers] << Swagger::Blocks::Nodes::ServerNode.call(version: version, inline_keys: inline_keys, &block)
         end
 
         # Use 'tag' instead.

--- a/lib/swagger/blocks/nodes/root_node.rb
+++ b/lib/swagger/blocks/nodes/root_node.rb
@@ -31,7 +31,7 @@ module Swagger
         end
 
         def security(inline_keys = nil, &block)
-          raise NotSupportedError unless is_swagger_2_0?
+          raise NotSupportedError unless is_swagger_2_0? || is_openapi_3_0?
 
           self.data[:security] ||= []
           self.data[:security] << Swagger::Blocks::Nodes::SecurityRequirementNode.call(version: version, inline_keys: inline_keys, &block)

--- a/lib/swagger/blocks/nodes/root_node.rb
+++ b/lib/swagger/blocks/nodes/root_node.rb
@@ -50,8 +50,16 @@ module Swagger
 
         def server(inline_keys = nil, &block)
           raise NotSupportedError unless is_openapi_3_0?
+
           self.data[:servers] ||= []
           self.data[:servers] << Swagger::Blocks::Nodes::ServerNode.call(version: version, inline_keys: inline_keys, &block)
+        end
+
+        def extension(name, inline_keys = nil, &block)
+          raise NotSupportedError unless is_openapi_3_0?
+
+          self.data[name] ||= []
+          self.data[name] << Swagger::Blocks::Nodes::VendorExtensionNode.call(version: version, inline_keys: inline_keys, &block)
         end
 
         # Use 'tag' instead.

--- a/lib/swagger/blocks/nodes/schema_node.rb
+++ b/lib/swagger/blocks/nodes/schema_node.rb
@@ -28,6 +28,11 @@ module Swagger
         def example(inline_keys = nil, &block)
           self.data[:example] = Swagger::Blocks::Nodes::ExampleNode.call(version: version, inline_keys: inline_keys, &block)
         end
+
+        def one_of(&block)
+          self.data[:oneOf] ||= []
+          self.data[:oneOf] << Swagger::Blocks::Nodes::OneOfNode.call(version: version, &block)
+        end
       end
     end
   end

--- a/lib/swagger/blocks/nodes/schema_node.rb
+++ b/lib/swagger/blocks/nodes/schema_node.rb
@@ -24,6 +24,10 @@ module Swagger
         def externalDocs(inline_keys = nil, &block)
           self.data[:externalDocs] = Swagger::Blocks::Nodes::ExternalDocsNode.call(version: version, inline_keys: inline_keys, &block)
         end
+
+        def example(inline_keys = nil, &block)
+          self.data[:example] = Swagger::Blocks::Nodes::ExampleNode.call(version: version, inline_keys: inline_keys, &block)
+        end
       end
     end
   end

--- a/lib/swagger/blocks/nodes/scopes_node.rb
+++ b/lib/swagger/blocks/nodes/scopes_node.rb
@@ -1,7 +1,6 @@
 module Swagger
   module Blocks
     module Nodes
-      # v2.0: https://github.com/swagger-api/swagger-spec/blob/master/versions/2.0.md#scopes-object
       class ScopesNode < Node
       end
     end

--- a/lib/swagger/blocks/nodes/security_scheme_node.rb
+++ b/lib/swagger/blocks/nodes/security_scheme_node.rb
@@ -1,12 +1,16 @@
 module Swagger
   module Blocks
     module Nodes
-      # v2.0: https://github.com/swagger-api/swagger-spec/blob/master/versions/2.0.md#security-scheme-object
       class SecuritySchemeNode < Node
         # TODO support ^x- Vendor Extensions
 
         def scopes(inline_keys = nil, &block)
           self.data[:scopes] = Swagger::Blocks::Nodes::ScopesNode.call(version: version, inline_keys: inline_keys, &block)
+        end
+
+        def flow(name, inline_keys = nil, &block)
+          self.data[:flows] ||= {}
+          self.data[:flows][name] = Swagger::Blocks::Nodes::FlowNode.call(version: version, inline_keys: inline_keys, &block)
         end
       end
     end

--- a/lib/swagger/blocks/nodes/server_node.rb
+++ b/lib/swagger/blocks/nodes/server_node.rb
@@ -1,0 +1,8 @@
+module Swagger
+  module Blocks
+    module Nodes
+      class ServerNode < Node
+      end
+    end
+  end
+end

--- a/lib/swagger/blocks/nodes/server_node.rb
+++ b/lib/swagger/blocks/nodes/server_node.rb
@@ -2,6 +2,10 @@ module Swagger
   module Blocks
     module Nodes
       class ServerNode < Node
+        def variable(name, inline_keys = nil, &block)
+          self.data[:variables] ||= {}
+          self.data[:variables][name] = Swagger::Blocks::Nodes::VariableNode.call(version: version, inline_keys: inline_keys, &block)
+        end
       end
     end
   end

--- a/lib/swagger/blocks/nodes/value_node.rb
+++ b/lib/swagger/blocks/nodes/value_node.rb
@@ -1,0 +1,8 @@
+module Swagger
+  module Blocks
+    module Nodes
+      class ValueNode < Node
+      end
+    end
+  end
+end

--- a/lib/swagger/blocks/nodes/variable_node.rb
+++ b/lib/swagger/blocks/nodes/variable_node.rb
@@ -1,0 +1,8 @@
+module Swagger
+  module Blocks
+    module Nodes
+      class VariableNode < Node
+      end
+    end
+  end
+end

--- a/lib/swagger/blocks/nodes/vendor_extension_node.rb
+++ b/lib/swagger/blocks/nodes/vendor_extension_node.rb
@@ -1,0 +1,9 @@
+module Swagger
+  module Blocks
+    module Nodes
+      # v3.0: https://swagger.io/docs/specification/openapi-extensions/
+      class VendorExtensionNode < Node
+      end
+    end
+  end
+end

--- a/lib/swagger/blocks/root.rb
+++ b/lib/swagger/blocks/root.rb
@@ -19,6 +19,13 @@ module Swagger
         end
       end
 
+      if data[:root_node].is_openapi_3_0?
+        data[:root_node].key(:paths, data[:path_nodes]) # Required, so no empty check.
+        if data[:component_node] && !data[:component_node].data.empty?
+          data[:root_node].key(:components, data[:component_node])
+        end
+      end
+
       data[:root_node].as_json
     end
   end

--- a/lib/swagger/blocks/root.rb
+++ b/lib/swagger/blocks/root.rb
@@ -26,7 +26,7 @@ module Swagger
         end
       end
 
-      data[:root_node].as_json
+      data[:root_node].as_json(version: data[:root_node].version)
     end
   end
 end

--- a/lib/swagger/blocks/version.rb
+++ b/lib/swagger/blocks/version.rb
@@ -1,5 +1,5 @@
 module Swagger
   module Blocks
-    VERSION = '2.1.0'
+    VERSION = '2.2.1'
   end
 end

--- a/lib/swagger/blocks/version.rb
+++ b/lib/swagger/blocks/version.rb
@@ -1,5 +1,5 @@
 module Swagger
   module Blocks
-    VERSION = '2.0.2'
+    VERSION = '2.1.0'
   end
 end

--- a/spec/lib/swagger_v3_api_declaration.json
+++ b/spec/lib/swagger_v3_api_declaration.json
@@ -45,6 +45,12 @@
       ]
     }
   ],
+  "x-tagGroups": [
+    {
+      "name": "Pets",
+      "tags": ["dogs", "cats"]
+    }
+  ],
   "tags": [
     {
       "name": "dogs",

--- a/spec/lib/swagger_v3_api_declaration.json
+++ b/spec/lib/swagger_v3_api_declaration.json
@@ -62,6 +62,17 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/Pets"
+                },
+                "examples": {
+                  "Rabbit": {
+                    "value": {
+                      "id": 10,
+                      "name": "Rabbit"
+                    }
+                  },
+                  "Cat": {
+                    "$ref": "#/components/examples/Cat"
+                  }
                 }
               }
             },
@@ -99,7 +110,6 @@
               "$ref": "#/components/schemas/PetInput"
             }
           }
-
         ],
         "responses": {
           "201": {
@@ -268,8 +278,14 @@
           "name": {
             "type": "string"
           },
-          "tag": {
-            "type": "string"
+          "tag_ids": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int64",
+              "example": 1
+            },
+            "example": [1, 2, 3]
           }
         }
       },
@@ -277,7 +293,8 @@
         "type": "array",
         "items": {
           "$ref": "#/components/schemas/Pet"
-        }
+        },
+        "example": [{"id": 10, "name": "Rover"}, {"id": 20, "name": "Felicity"}]
       },
       "PetOrderRequest": {
         "required": [
@@ -331,6 +348,11 @@
           "status": {
             "type": "string"
           }
+        },
+        "example": {
+          "order_id": 123,
+          "phone_number": "3125556666",
+          "status": "complete"
         }
       },
       "Error": {
@@ -355,6 +377,22 @@
         "parameters": {
           "petId": "$response.body#/id"
         }
+      }
+    },
+    "examples": {
+      "PetExample": {
+        "value": {
+          "id": 1,
+          "name": "Rover"
+        },
+        "summary": "An example pet response"
+      },
+      "Cat": {
+        "value": {
+          "id": 1,
+          "name": "Felicity"
+        },
+        "summary": "An example cat response"
       }
     }
   }

--- a/spec/lib/swagger_v3_api_declaration.json
+++ b/spec/lib/swagger_v3_api_declaration.json
@@ -394,6 +394,39 @@
         },
         "summary": "An example cat response"
       }
+    },
+    "securitySchemes": {
+      "BasicAuth": {
+        "type": "http",
+        "scheme": "basic"
+      },
+      "BearerAuth": {
+        "type": "http",
+        "scheme": "bearer"
+      },
+      "ApiKeyAuth": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "X-API-Key"
+      },
+      "OpenID": {
+        "type": "openIdConnect",
+        "openIdConnectUrl": "https://example.com/.well-known/openid-configuration"
+      },
+      "OAuth2": {
+        "type": "oauth2",
+        "flows": {
+          "authorizationCode": {
+            "authorizationUrl": "https://example.com/oauth/authorize",
+            "tokenUrl": "https://example.com/oauth/token",
+            "scopes": {
+              "read": "Grants read access",
+              "write": "Grants write access",
+              "admin": "Grants access to admin operations"
+            }
+          }
+        }
+      }
     }
   }
 }

--- a/spec/lib/swagger_v3_api_declaration.json
+++ b/spec/lib/swagger_v3_api_declaration.json
@@ -1,0 +1,202 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "version": "1.0.1",
+    "title": "Swagger Petstore",
+    "description": "A sample API that uses a petstore as an example to demonstrate features in the swagger-2.0 specification",
+    "termsOfService": "http://helloreverb.com/terms/",
+    "contact": {
+      "name": "Wordnik API Team"
+    },
+    "license": {
+      "name": "MIT"
+    }
+  },
+  "servers": [
+    {
+      "url": "http://petstore.swagger.io/v1"
+    }
+  ],
+  "tags": [
+    {
+      "name": "dogs",
+      "description": "Dogs"
+    },
+    {
+      "name": "cats",
+      "description": "Cats"
+    }
+  ],
+  "paths": {
+    "/pets": {
+      "get": {
+        "summary": "List all pets",
+        "operationId": "listPets",
+        "tags": [
+          "pets"
+        ],
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "How many items to return at one time (max 100)",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A paged array of pets",
+            "headers": {
+              "x-next": {
+                "description": "A link to the next page of responses",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Pets"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "summary": "Create a pet",
+        "operationId": "createPets",
+        "tags": [
+          "pets"
+        ],
+        "parameters": [
+          {
+            "name": "pet",
+            "in": "body",
+            "description": "Pet to add to the store",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/PetInput"
+            }
+          }
+
+        ],
+        "responses": {
+          "201": {
+            "description": "Null response"
+          },
+          "default": {
+            "description": "unexpected error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/pets/{petId}": {
+      "get": {
+        "summary": "Info for a specific pet",
+        "operationId": "showPetById",
+        "tags": [
+          "pets"
+        ],
+        "parameters": [
+          {
+            "name": "petId",
+            "in": "path",
+            "required": true,
+            "description": "The id of the pet to retrieve",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Expected response to a valid request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Pet"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Pet": {
+        "required": [
+          "id",
+          "name"
+        ],
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "name": {
+            "type": "string"
+          },
+          "tag": {
+            "type": "string"
+          }
+        }
+      },
+      "Pets": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/Pet"
+        }
+      },
+      "Error": {
+        "required": [
+          "code",
+          "message"
+        ],
+        "properties": {
+          "code": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "message": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/spec/lib/swagger_v3_api_declaration.json
+++ b/spec/lib/swagger_v3_api_declaration.json
@@ -14,7 +14,19 @@
   },
   "servers": [
     {
-      "url": "http://petstore.swagger.io/v1"
+      "url": "http://petstore.swagger.io/v1",
+      "description": "Petstore API"
+    }
+  ],
+  "security": [
+    {
+      "ApiKeyAuth": []
+    },
+    {
+      "OAuth2": [
+        "read",
+        "write"
+      ]
     }
   ],
   "tags": [

--- a/spec/lib/swagger_v3_api_declaration.json
+++ b/spec/lib/swagger_v3_api_declaration.json
@@ -244,14 +244,7 @@
         },
         "responses": {
           "200": {
-            "description": "Expected response to a valid request",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Pet"
-                }
-              }
-            }
+            "$ref": "#/components/responses/ReplacePetBodyResponse"
           },
           "default": {
             "description": "unexpected error",
@@ -455,6 +448,18 @@
       "PetBody": {
         "description": "A JSON object containing pet information",
         "required": true,
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/Pet"
+            }
+          }
+        }
+      }
+    },
+    "responses" : {
+      "ReplacePetBodyResponse": {
+        "description": "Expected response to a valid request",
         "content": {
           "application/json": {
             "schema": {

--- a/spec/lib/swagger_v3_api_declaration.json
+++ b/spec/lib/swagger_v3_api_declaration.json
@@ -154,6 +154,82 @@
           }
         }
       }
+    },
+    "/pets/{petId}/purchase": {
+      "post": {
+        "summary": "Purchase a specific pet",
+        "operationId": "purchasePetById",
+        "tags": [
+          "pets"
+        ],
+        "parameters": [
+          {
+            "name": "petId",
+            "in": "path",
+            "required": true,
+            "description": "The id of the pet to retrieve",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "Pet order object",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PetOrderRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Expected response to a valid request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PetOrder"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "callbacks": {
+          "orderUpdated": {
+            "{$request.body#/webhook_url}": {
+              "post": {
+                "requestBody": {
+                  "required": true,
+                  "content": {
+                    "application/json": {
+                      "schema": {
+                        "$ref": "#/components/schemas/OrderUpdated"
+                      }
+                    }
+                  }
+                },
+                "responses": {
+                  "200": {
+                    "description": "The server must return an HTTP 200, otherwise delivery will be reattempted."
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "components": {
@@ -180,6 +256,60 @@
         "type": "array",
         "items": {
           "$ref": "#/components/schemas/Pet"
+        }
+      },
+      "PetOrderRequest": {
+        "required": [
+          "phone_number"
+        ],
+        "properties": {
+          "phone_number": {
+            "type": "string"
+          },
+          "webhook_url": {
+            "type": "string"
+          }
+        }
+      },
+      "PetOrder": {
+        "required": [
+          "phone_number",
+          "id",
+          "status"
+        ],
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "phone_number": {
+            "type": "string"
+          },
+          "webhook_url": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          }
+        }
+      },
+      "OrderUpdated": {
+        "required": [
+          "order_id",
+          "status",
+          "phone_number"
+        ],
+        "properties": {
+          "order_id": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "phone_number": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          }
         }
       },
       "Error": {

--- a/spec/lib/swagger_v3_api_declaration.json
+++ b/spec/lib/swagger_v3_api_declaration.json
@@ -243,6 +243,31 @@
           }
         }
       },
+      "post": {
+        "summary": "Update info for a specific pet",
+        "operationId": "updatePetById",
+        "tags": [
+          "pets"
+        ],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/PetBody"
+        },
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/UpdatePetBodyResponse"
+          },
+          "default": {
+            "description": "unexpected error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      },
       "put": {
         "summary": "Replace info for a specific pet",
         "operationId": "replacePetById",
@@ -468,6 +493,16 @@
       }
     },
     "responses" : {
+      "UpdatePetBodyResponse": {
+        "description": "Expected response to a valid request",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/Pet"
+            }
+          }
+        }
+      },
       "ReplacePetBodyResponse": {
         "description": "Expected response to a valid request",
         "content": {

--- a/spec/lib/swagger_v3_api_declaration.json
+++ b/spec/lib/swagger_v3_api_declaration.json
@@ -64,6 +64,11 @@
                   "$ref": "#/components/schemas/Pets"
                 }
               }
+            },
+            "links": {
+              "getPetById": {
+                "$ref": "#/components/links/GetPetById"
+              }
             }
           },
           "default": {
@@ -98,7 +103,23 @@
         ],
         "responses": {
           "201": {
-            "description": "Null response"
+            "description": "New Pet",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Pet"
+                }
+              }
+            },
+            "links": {
+              "getPetById": {
+                "operationId": "showPetById",
+                "parameters": {
+                  "id": "$response.body#/id"
+                },
+                "description": "The `id` value returned in the response can be used as the `petId` parameter in `GET /pets/{petId}`."
+              }
+            }
           },
           "default": {
             "description": "unexpected error",
@@ -325,6 +346,14 @@
           "message": {
             "type": "string"
           }
+        }
+      }
+    },
+    "links": {
+      "GetPetById": {
+        "operationId": "showPetById",
+        "parameters": {
+          "petId": "$response.body#/id"
         }
       }
     }

--- a/spec/lib/swagger_v3_api_declaration.json
+++ b/spec/lib/swagger_v3_api_declaration.json
@@ -57,6 +57,13 @@
   ],
   "paths": {
     "/pets": {
+      "description": "Perform actions on pet resources",
+      "servers": [
+        {
+          "url": "http://petstore.swagger.io/",
+          "description": "Petstore API (without version prefix)"
+        }
+      ],
       "get": {
         "summary": "List all pets",
         "operationId": "listPets",
@@ -73,6 +80,12 @@
               "type": "integer",
               "format": "int32"
             }
+          }
+        ],
+        "servers": [
+          {
+            "url": "http://petstore.swagger.io/2.1/",
+            "description": "Petstore API (with version 2.1 prefix)"
           }
         ],
         "responses": {
@@ -180,23 +193,55 @@
       }
     },
     "/pets/{petId}": {
+      "parameters": [
+        {
+          "name": "petId",
+          "in": "path",
+          "required": true,
+          "description": "The id of the pet to retrieve",
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
       "get": {
         "summary": "Info for a specific pet",
         "operationId": "showPetById",
         "tags": [
           "pets"
         ],
-        "parameters": [
-          {
-            "name": "petId",
-            "in": "path",
-            "required": true,
-            "description": "The id of the pet to retrieve",
-            "schema": {
-              "type": "string"
+        "responses": {
+          "200": {
+            "description": "Expected response to a valid request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Pet"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
             }
           }
+        }
+      },
+      "put": {
+        "summary": "Replace info for a specific pet",
+        "operationId": "replacePetById",
+        "tags": [
+          "pets"
         ],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/PetBody"
+        },
         "responses": {
           "200": {
             "description": "Expected response to a valid request",
@@ -225,19 +270,12 @@
       "post": {
         "summary": "Purchase a specific pet",
         "operationId": "purchasePetById",
+        "deprecated": true,
         "tags": [
           "pets"
         ],
         "parameters": [
-          {
-            "name": "petId",
-            "in": "path",
-            "required": true,
-            "description": "The id of the pet to retrieve",
-            "schema": {
-              "type": "string"
-            }
-          }
+          {"$ref": "#/components/parameters/petId"}
         ],
         "requestBody": {
           "description": "Pet order object",
@@ -245,7 +283,10 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/PetOrderRequest"
+                "oneOf": [
+                  {"$ref": "#/components/schemas/PetOrderRequest"},
+                  {"$ref": "#/components/schemas/ComplexPetOrderRequest"}
+                ]
               },
               "example": {
                 "id": 10,
@@ -410,6 +451,19 @@
         }
       }
     },
+    "requestBodies": {
+      "PetBody": {
+        "description": "A JSON object containing pet information",
+        "required": true,
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/Pet"
+            }
+          }
+        }
+      }
+    },
     "links": {
       "GetPetById": {
         "operationId": "showPetById",
@@ -464,6 +518,17 @@
               "admin": "Grants access to admin operations"
             }
           }
+        }
+      }
+    },
+    "parameters": {
+      "petId": {
+        "name": "petId",
+        "in": "path",
+        "required": true,
+        "description": "The id of the pet to retrieve",
+        "schema": {
+          "type": "string"
         }
       }
     }

--- a/spec/lib/swagger_v3_api_declaration.json
+++ b/spec/lib/swagger_v3_api_declaration.json
@@ -16,6 +16,22 @@
     {
       "url": "http://petstore.swagger.io/v1",
       "description": "Petstore API"
+    },
+    {
+      "url": "https://{subdomain}.site.com/{version}",
+      "description": "The main prod server",
+      "variables": {
+        "subdomain": {
+          "default": "production"
+        },
+        "version": {
+          "enum": [
+            "v1",
+            "v2"
+          ],
+          "default": "v2"
+        }
+      }
     }
   ],
   "security": [
@@ -112,17 +128,24 @@
         "tags": [
           "pets"
         ],
-        "parameters": [
-          {
-            "name": "pet",
-            "in": "body",
-            "description": "Pet to add to the store",
-            "required": true,
-            "schema": {
-              "$ref": "#/components/schemas/PetInput"
+        "requestBody": {
+          "description": "Pet to add to the store",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  }
+                },
+                "example": {
+                  "name": "Fluffy"
+                }
+              }
             }
           }
-        ],
+        },
         "responses": {
           "201": {
             "description": "New Pet",
@@ -223,6 +246,10 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/PetOrderRequest"
+              },
+              "example": {
+                "id": 10,
+                "name": "Fluffy"
               }
             }
           }

--- a/spec/lib/swagger_v3_api_declaration.json
+++ b/spec/lib/swagger_v3_api_declaration.json
@@ -79,6 +79,16 @@
             "schema": {
               "type": "integer",
               "format": "int32"
+            },
+            "examples": {
+              "large": {
+                "value": 100,
+                "summary": "Return a maximum of 100 results"
+              },
+              "small": {
+                "value": 5,
+                "summary": "Return a maximum of 5 results"
+              }
             }
           }
         ],

--- a/spec/lib/swagger_v3_blocks_spec.rb
+++ b/spec/lib/swagger_v3_blocks_spec.rb
@@ -1,7 +1,7 @@
 require 'json'
 require 'swagger/blocks'
 
-# TODO Test data originally based on the Swagger UI example data
+# TODO: Test data originally based on the Swagger UI example data
 
 RESOURCE_LISTING_JSON_V3 = open(File.expand_path('../swagger_v3_api_declaration.json', __FILE__)).read
 
@@ -24,19 +24,19 @@ class PetControllerV3
     end
 
     server do
-      key :url, "http://petstore.swagger.io/v1"
-      key :description, "Petstore API"
+      key :url, 'http://petstore.swagger.io/v1'
+      key :description, 'Petstore API'
     end
 
     server do
-      key :url, "https://{subdomain}.site.com/{version}"
-      key :description, "The main prod server"
+      key :url, 'https://{subdomain}.site.com/{version}'
+      key :description, 'The main prod server'
 
       variable :subdomain do
         key :default, :production
       end
       variable :version do
-        key :enum, ["v1", "v2"]
+        key :enum, ['v1', 'v2']
         key :default, :v2
       end
     end
@@ -45,25 +45,30 @@ class PetControllerV3
       key :ApiKeyAuth, []
     end
     security do
-      key :OAuth2, ["read", "write"]
+      key :OAuth2, ['read', 'write']
+    end
+
+    extension :'x-tagGroups' do
+      key :name, 'Pets'
+      key :tags, ['dogs', 'cats']
     end
 
     tag do
-      key :name, "dogs"
-      key :description, "Dogs"
+      key :name, 'dogs'
+      key :description, 'Dogs'
     end
 
     tag do
-      key :name, "cats"
-      key :description, "Cats"
+      key :name, 'cats'
+      key :description, 'Cats'
     end
   end
 
   swagger_path '/pets' do
-    key :description, "Perform actions on pet resources"
+    key :description, 'Perform actions on pet resources'
     server do
-      key :url, "http://petstore.swagger.io/"
-      key :description, "Petstore API (without version prefix)"
+      key :url, 'http://petstore.swagger.io/'
+      key :description, 'Petstore API (without version prefix)'
     end
     operation :get do
       key :summary, 'List all pets'
@@ -82,16 +87,16 @@ class PetControllerV3
         end
         example :large do
           key :value, 100
-          key :summary, "Return a maximum of 100 results"
+          key :summary, 'Return a maximum of 100 results'
         end
         example :small do
           key :value, 5
-          key :summary, "Return a maximum of 5 results"
+          key :summary, 'Return a maximum of 5 results'
         end
       end
       server do
-        key :url, "http://petstore.swagger.io/2.1/"
-        key :description, "Petstore API (with version 2.1 prefix)"
+        key :url, 'http://petstore.swagger.io/2.1/'
+        key :description, 'Petstore API (with version 2.1 prefix)'
       end
       response 200 do
         key :description, 'A paged array of pets'
@@ -108,14 +113,14 @@ class PetControllerV3
           example :Rabbit do
             value do
               key :id, 10
-              key :name, "Rabbit"
+              key :name, 'Rabbit'
             end
           end
           example :Cat do
             key :'$ref', :Cat
           end
         end
-        link :'getPetById' do
+        link :getPetById do
           key :'$ref', '#/components/links/GetPetById'
         end
       end
@@ -137,13 +142,13 @@ class PetControllerV3
       request_body do
         key :description, 'Pet to add to the store'
         key :required, true
-        content "application/json" do
+        content 'application/json' do
           schema do
             property :name do
               key :type, :string
             end
             example do
-              key :name, "Fluffy"
+              key :name, 'Fluffy'
             end
           end
         end
@@ -156,11 +161,11 @@ class PetControllerV3
           end
         end
         link :getPetById do
-          key :operationId, "showPetById"
+          key :operationId, 'showPetById'
           parameters do
-            key :id, "$response.body#/id"
+            key :id, '$response.body#/id'
           end
-          key :description, "The `id` value returned in the response can be used as the `petId` parameter in `GET /pets/{petId}`."
+          key :description, 'The `id` value returned in the response can be used as the `petId` parameter in `GET /pets/{petId}`.'
         end
       end
       response :default, description: 'unexpected error' do
@@ -266,20 +271,20 @@ class PetV3
         key :$ref, :petId
       end
       request_body do
-        key :description, "Pet order object"
+        key :description, 'Pet order object'
         key :required, true
-        content "application/json" do
+        content 'application/json' do
           schema do
             one_of do
-              key :'$ref', "PetOrderRequest"
+              key :'$ref', 'PetOrderRequest'
             end
             one_of do
-              key :'$ref', "ComplexPetOrderRequest"
+              key :'$ref', 'ComplexPetOrderRequest'
             end
           end
           example do
             key :id, 10
-            key :name, "Fluffy"
+            key :name, 'Fluffy'
           end
         end
       end
@@ -301,18 +306,18 @@ class PetV3
       end
 
       callback :orderUpdated do
-        destination "{$request.body#/webhook_url}" do
+        destination '{$request.body#/webhook_url}' do
           method :post do
             request_body do
               key :required, true
-              content "application/json" do
+              content 'application/json' do
                 schema do
                   key :'$ref', :OrderUpdated
                 end
               end
             end
             response 200 do
-              key :description, "The server must return an HTTP 200, otherwise delivery will be reattempted."
+              key :description, 'The server must return an HTTP 200, otherwise delivery will be reattempted.'
             end
           end
         end
@@ -335,7 +340,7 @@ class PetV3
           key :format, :int64
           key :example, 1
         end
-        key :example, [1,2,3]
+        key :example, [1, 2, 3]
       end
     end
 
@@ -344,7 +349,7 @@ class PetV3
       items do
         key :'$ref', :Pet
       end
-      key :example, [{id: 10, name: "Rover"}, {id: 20, name: "Felicity"}]
+      key :example, [{ id: 10, name: 'Rover' }, { id: 20, name: 'Felicity' }]
     end
 
     schema :PetOrderRequest, required: [:phone_number] do
@@ -385,24 +390,24 @@ class PetV3
       end
       example do
         key :order_id, 123
-        key :phone_number, "3125556666"
-        key :status, "complete"
+        key :phone_number, '3125556666'
+        key :status, 'complete'
       end
     end
 
     link :GetPetById do
       key :operationId, :showPetById
       parameters do
-        key :petId, "$response.body#/id"
+        key :petId, '$response.body#/id'
       end
     end
 
     example :PetExample do
       value do
         key :id, 1
-        key :name, "Rover"
+        key :name, 'Rover'
       end
-      key :summary, "An example pet response"
+      key :summary, 'An example pet response'
     end
     security_scheme :BasicAuth do
       key :type, :http
@@ -419,7 +424,7 @@ class PetV3
     end
     security_scheme :OpenID do
       key :type, :openIdConnect
-      key :openIdConnectUrl, "https://example.com/.well-known/openid-configuration"
+      key :openIdConnectUrl, 'https://example.com/.well-known/openid-configuration'
     end
     parameter :petId do
       key :name, :petId
@@ -482,19 +487,19 @@ class AuxiliaryModelV3
     example :Cat do
       value do
         key :id, 1
-        key :name, "Felicity"
+        key :name, 'Felicity'
       end
-      key :summary, "An example cat response"
+      key :summary, 'An example cat response'
     end
     security_scheme :OAuth2 do
       key :type, :oauth2
       flow :authorizationCode do
-        key :authorizationUrl, "https://example.com/oauth/authorize"
-        key :tokenUrl, "https://example.com/oauth/token"
+        key :authorizationUrl, 'https://example.com/oauth/authorize'
+        key :tokenUrl, 'https://example.com/oauth/token'
         scopes do
-          key :read, "Grants read access"
-          key :write, "Grants write access"
-          key :admin, "Grants access to admin operations"
+          key :read, 'Grants read access'
+          key :write, 'Grants write access'
+          key :admin, 'Grants access to admin operations'
         end
       end
     end
@@ -511,11 +516,12 @@ describe 'Swagger::Blocks v3' do
         AuxiliaryModelV3
       ]
       actual = Swagger::Blocks.build_root_json(swaggered_classes)
-      actual = JSON.parse(actual.to_json)  # For access consistency.
+      actual = JSON.parse(actual.to_json) # For access consistency.
       data = JSON.parse(RESOURCE_LISTING_JSON_V3)
 
       # Multiple expectations for better test diff output.
       expect(actual['info']).to eq(data['info'])
+      expect(actual['x-tagGroups']).to eq(data['x-tagGroups'])
       expect(actual['paths']).to be
       expect(actual['paths']['/pets']).to be
       expect(actual['paths']['/pets']).to eq(data['paths']['/pets'])
@@ -535,15 +541,15 @@ describe 'Swagger::Blocks v3' do
     end
 
     it 'errors if no swagger_root is declared' do
-      expect {
+      expect do
         Swagger::Blocks.build_root_json([])
-      }.to raise_error(Swagger::Blocks::DeclarationError)
+      end.to raise_error(Swagger::Blocks::DeclarationError)
     end
 
     it 'errors if multiple swagger_roots are declared' do
-      expect {
+      expect do
         Swagger::Blocks.build_root_json([PetControllerV3, PetControllerV3])
-      }.to raise_error(Swagger::Blocks::DeclarationError)
+      end.to raise_error(Swagger::Blocks::DeclarationError)
     end
   end
 end

--- a/spec/lib/swagger_v3_blocks_spec.rb
+++ b/spec/lib/swagger_v3_blocks_spec.rb
@@ -323,6 +323,35 @@ class PetV3
       end
       key :summary, "An example cat response"
     end
+    security_scheme :BasicAuth do
+      key :type, :http
+      key :scheme, :basic
+    end
+    security_scheme :BearerAuth do
+      key :type, :http
+      key :scheme, :bearer
+    end
+    security_scheme :ApiKeyAuth do
+      key :type, :apiKey
+      key :in, :header
+      key :name, :"X-API-Key"
+    end
+    security_scheme :OpenID do
+      key :type, :openIdConnect
+      key :openIdConnectUrl, "https://example.com/.well-known/openid-configuration"
+    end
+    security_scheme :OAuth2 do
+      key :type, :oauth2
+      flow :authorizationCode do
+        key :authorizationUrl, "https://example.com/oauth/authorize"
+        key :tokenUrl, "https://example.com/oauth/token"
+        scopes do
+          key :read, "Grants read access"
+          key :write, "Grants write access"
+          key :admin, "Grants access to admin operations"
+        end
+      end
+    end
   end
 end
 

--- a/spec/lib/swagger_v3_blocks_spec.rb
+++ b/spec/lib/swagger_v3_blocks_spec.rb
@@ -60,6 +60,11 @@ class PetControllerV3
   end
 
   swagger_path '/pets' do
+    key :description, "Perform actions on pet resources"
+    server do
+      key :url, "http://petstore.swagger.io/"
+      key :description, "Petstore API (without version prefix)"
+    end
     operation :get do
       key :summary, 'List all pets'
       key :operationId, 'listPets'
@@ -75,6 +80,10 @@ class PetControllerV3
           key :type, :integer
           key :format, :int32
         end
+      end
+      server do
+        key :url, "http://petstore.swagger.io/2.1/"
+        key :description, "Petstore API (with version 2.1 prefix)"
       end
       response 200 do
         key :description, 'A paged array of pets'
@@ -157,20 +166,46 @@ class PetControllerV3
   end
 
   swagger_path '/pets/{petId}' do
+    parameter do
+      key :name, :petId
+      key :in, :path
+      key :required, true
+      key :description, 'The id of the pet to retrieve'
+      schema do
+        key :type, 'string'
+      end
+    end
     operation :get do
       key :summary, 'Info for a specific pet'
       key :operationId, 'showPetById'
       key :tags, [
         'pets'
       ]
-      parameter do
-        key :name, :petId
-        key :in, :path
-        key :required, true
-        key :description, 'The id of the pet to retrieve'
-        schema do
-          key :type, 'string'
+      response 200 do
+        key :description, 'Expected response to a valid request'
+        content :'application/json' do
+          schema do
+            key :'$ref', :Pet
+          end
         end
+      end
+      response :default do
+        key :description, 'unexpected error'
+        content :'application/json' do
+          schema do
+            key :'$ref', :Error
+          end
+        end
+      end
+    end
+    operation :put do
+      key :summary, 'Replace info for a specific pet'
+      key :operationId, 'replacePetById'
+      key :tags, [
+        'pets'
+      ]
+      request_body do
+        key :"$ref", :PetBody
       end
       response 200 do
         key :description, 'Expected response to a valid request'
@@ -195,24 +230,24 @@ class PetControllerV3
     operation :post do
       key :summary, 'Purchase a specific pet'
       key :operationId, 'purchasePetById'
+      key :deprecated, true
       key :tags, [
         'pets'
       ]
       parameter do
-        key :name, :petId
-        key :in, :path
-        key :required, true
-        key :description, 'The id of the pet to retrieve'
-        schema do
-          key :type, 'string'
-        end
+        key :$ref, :petId
       end
       request_body do
         key :description, "Pet order object"
         key :required, true
         content "application/json" do
           schema do
-            key :'$ref', "PetOrderRequest"
+            one_of do
+              key :'$ref', "PetOrderRequest"
+            end
+            one_of do
+              key :'$ref', "ComplexPetOrderRequest"
+            end
           end
           example do
             key :id, 10
@@ -379,6 +414,24 @@ class PetV3
           key :read, "Grants read access"
           key :write, "Grants write access"
           key :admin, "Grants access to admin operations"
+        end
+      end
+    end
+    parameter :petId do
+      key :name, :petId
+      key :in, :path
+      key :required, true
+      key :description, 'The id of the pet to retrieve'
+      schema do
+        key :type, 'string'
+      end
+    end
+    request_body :PetBody do
+      key :description, 'A JSON object containing pet information'
+      key :required, true
+      content :'application/json' do
+        schema do
+          key :'$ref', :Pet
         end
       end
     end

--- a/spec/lib/swagger_v3_blocks_spec.rb
+++ b/spec/lib/swagger_v3_blocks_spec.rb
@@ -80,6 +80,14 @@ class PetControllerV3
           key :type, :integer
           key :format, :int32
         end
+        example :large do
+          key :value, 100
+          key :summary, "Return a maximum of 100 results"
+        end
+        example :small do
+          key :value, 5
+          key :summary, "Return a maximum of 5 results"
+        end
       end
       server do
         key :url, "http://petstore.swagger.io/2.1/"

--- a/spec/lib/swagger_v3_blocks_spec.rb
+++ b/spec/lib/swagger_v3_blocks_spec.rb
@@ -67,6 +67,15 @@ class PetControllerV3
           schema do
             key :'$ref', :Pets
           end
+          example :Rabbit do
+            value do
+              key :id, 10
+              key :name, "Rabbit"
+            end
+          end
+          example :Cat do
+            key :'$ref', :Cat
+          end
         end
         link :'getPetById' do
           key :'$ref', '#/components/links/GetPetById'
@@ -231,8 +240,14 @@ class PetV3
       property :name do
         key :type, :string
       end
-      property :tag do
-        key :type, :string
+      property :tag_ids do
+        key :type, :array
+        items do
+          key :type, :integer
+          key :format, :int64
+          key :example, 1
+        end
+        key :example, [1,2,3]
       end
     end
 
@@ -241,6 +256,7 @@ class PetV3
       items do
         key :'$ref', :Pet
       end
+      key :example, [{id: 10, name: "Rover"}, {id: 20, name: "Felicity"}]
     end
 
     schema :PetOrderRequest, required: [:phone_number] do
@@ -279,6 +295,11 @@ class PetV3
       property :status do
         key :type, :string
       end
+      example do
+        key :order_id, 123
+        key :phone_number, "3125556666"
+        key :status, "complete"
+      end
     end
 
     link :GetPetById do
@@ -286,6 +307,21 @@ class PetV3
       parameters do
         key :petId, "$response.body#/id"
       end
+    end
+
+    example :PetExample do
+      value do
+        key :id, 1
+        key :name, "Rover"
+      end
+      key :summary, "An example pet response"
+    end
+    example :Cat do
+      value do
+        key :id, 1
+        key :name, "Felicity"
+      end
+      key :summary, "An example cat response"
     end
   end
 end

--- a/spec/lib/swagger_v3_blocks_spec.rb
+++ b/spec/lib/swagger_v3_blocks_spec.rb
@@ -1,0 +1,229 @@
+require 'json'
+require 'swagger/blocks'
+
+# TODO Test data originally based on the Swagger UI example data
+
+RESOURCE_LISTING_JSON_V3 = open(File.expand_path('../swagger_v3_api_declaration.json', __FILE__)).read
+
+class PetControllerV3
+  include Swagger::Blocks
+
+  swagger_root do
+    key :openapi, '3.0.0'
+    info version: '1.0.1' do
+      key :title, 'Swagger Petstore'
+      key :description, 'A sample API that uses a petstore as an example to ' \
+                        'demonstrate features in the swagger-2.0 specification'
+      key :termsOfService, 'http://helloreverb.com/terms/'
+      contact do
+        key :name, 'Wordnik API Team'
+      end
+      license do
+        key :name, 'MIT'
+      end
+    end
+
+    server do
+      key :url, "http://petstore.swagger.io/v1"
+    end
+
+    tag do
+      key :name, "dogs"
+      key :description, "Dogs"
+    end
+
+    tag do
+      key :name, "cats"
+      key :description, "Cats"
+    end
+  end
+
+  swagger_path '/pets' do
+    operation :get do
+      key :summary, 'List all pets'
+      key :operationId, 'listPets'
+      key :tags, [
+        'pets'
+      ]
+      parameter do
+        key :name, :limit
+        key :in, :query
+        key :description, 'How many items to return at one time (max 100)'
+        key :required, false
+        schema do
+          key :type, :integer
+          key :format, :int32
+        end
+      end
+      response 200 do
+        key :description, 'A paged array of pets'
+        header :'x-next' do
+          key :description, 'A link to the next page of responses'
+          schema do
+            key :type, :string
+          end
+        end
+        content :'application/json' do
+          schema do
+            key :'$ref', :Pets
+          end
+        end
+      end
+      response :default do
+        key :description, 'unexpected error'
+        content :'application/json' do
+          schema do
+            key :'$ref', :Error
+          end
+        end
+      end
+    end
+    operation :post do
+      key :summary, 'Create a pet'
+      key :operationId, 'createPets'
+      key :tags, [
+        'pets'
+      ]
+      parameter do
+        key :name, :pet
+        key :in, :body
+        key :description, 'Pet to add to the store'
+        key :required, true
+        schema do
+          key :'$ref', :PetInput
+        end
+      end
+      response 201 do
+        key :description, 'Null response'
+      end
+      response :default, description: 'unexpected error' do
+        content :'application/json' do
+          schema do
+            key :'$ref', :Error
+          end
+        end
+      end
+    end
+  end
+
+  swagger_path '/pets/{petId}' do
+    operation :get do
+      key :summary, 'Info for a specific pet'
+      key :operationId, 'showPetById'
+      key :tags, [
+        'pets'
+      ]
+      parameter do
+        key :name, :petId
+        key :in, :path
+        key :required, true
+        key :description, 'The id of the pet to retrieve'
+        schema do
+          key :type, 'string'
+        end
+      end
+      response 200 do
+        key :description, 'Expected response to a valid request'
+        content :'application/json' do
+          schema do
+            key :'$ref', :Pet
+          end
+        end
+      end
+      response :default do
+        key :description, 'unexpected error'
+        content :'application/json' do
+          schema do
+            key :'$ref', :Error
+          end
+        end
+      end
+    end
+  end
+end
+
+class PetV3
+  include Swagger::Blocks
+
+  swagger_component do
+    schema :Pet, required: [:id, :name] do
+      property :id do
+        key :type, :integer
+        key :format, :int64
+      end
+      property :name do
+        key :type, :string
+      end
+      property :tag do
+        key :type, :string
+      end
+    end
+
+    schema :Pets do
+      key :type, :array
+      items do
+        key :'$ref', :Pet
+      end
+    end
+  end
+end
+
+class ErrorModelV3
+  include Swagger::Blocks
+
+  swagger_component do
+    schema :Error do
+      key :required, [:code, :message]
+      property :code do
+        key :type, :integer
+        key :format, :int32
+      end
+      property :message do
+        key :type, :string
+      end
+    end
+  end
+end
+
+describe 'Swagger::Blocks v3' do
+  describe 'build_json' do
+    it 'outputs the correct data' do
+      swaggered_classes = [
+        PetControllerV3,
+        PetV3,
+        ErrorModelV3
+      ]
+      actual = Swagger::Blocks.build_root_json(swaggered_classes)
+      actual = JSON.parse(actual.to_json)  # For access consistency.
+      data = JSON.parse(RESOURCE_LISTING_JSON_V3)
+
+      # Multiple expectations for better test diff output.
+      expect(actual['info']).to eq(data['info'])
+      expect(actual['paths']).to be
+      expect(actual['paths']['/pets']).to be
+      expect(actual['paths']['/pets']).to eq(data['paths']['/pets'])
+      expect(actual['paths']['/pets/{petId}']).to be
+      expect(actual['paths']['/pets/{petId}']['get']).to be
+      expect(actual['paths']['/pets/{petId}']['get']).to eq(data['paths']['/pets/{petId}']['get'])
+      expect(actual['paths']).to eq(data['paths'])
+      expect(actual['components']).to eq(data['components'])
+      expect(actual).to eq(data)
+    end
+    it 'is idempotent' do
+      swaggered_classes = [PetControllerV3, PetV3, ErrorModelV3]
+      actual = JSON.parse(Swagger::Blocks.build_root_json(swaggered_classes).to_json)
+      data = JSON.parse(RESOURCE_LISTING_JSON_V3)
+      expect(actual).to eq(data)
+    end
+    it 'errors if no swagger_root is declared' do
+      expect {
+        Swagger::Blocks.build_root_json([])
+      }.to raise_error(Swagger::Blocks::DeclarationError)
+    end
+    it 'errors if multiple swagger_roots are declared' do
+      expect {
+        Swagger::Blocks.build_root_json([PetControllerV3, PetControllerV3])
+      }.to raise_error(Swagger::Blocks::DeclarationError)
+    end
+  end
+end

--- a/spec/lib/swagger_v3_blocks_spec.rb
+++ b/spec/lib/swagger_v3_blocks_spec.rb
@@ -68,6 +68,9 @@ class PetControllerV3
             key :'$ref', :Pets
           end
         end
+        link :'getPetById' do
+          key :'$ref', '#/components/links/GetPetById'
+        end
       end
       response :default do
         key :description, 'unexpected error'
@@ -94,7 +97,19 @@ class PetControllerV3
         end
       end
       response 201 do
-        key :description, 'Null response'
+        key :description, 'New Pet'
+        content :'application/json' do
+          schema do
+            key :'$ref', :Pet
+          end
+        end
+        link :getPetById do
+          key :operationId, "showPetById"
+          parameters do
+            key :id, "$response.body#/id"
+          end
+          key :description, "The `id` value returned in the response can be used as the `petId` parameter in `GET /pets/{petId}`."
+        end
       end
       response :default, description: 'unexpected error' do
         content :'application/json' do
@@ -263,6 +278,13 @@ class PetV3
       end
       property :status do
         key :type, :string
+      end
+    end
+
+    link :GetPetById do
+      key :operationId, :showPetById
+      parameters do
+        key :petId, "$response.body#/id"
       end
     end
   end

--- a/spec/lib/swagger_v3_blocks_spec.rb
+++ b/spec/lib/swagger_v3_blocks_spec.rb
@@ -25,6 +25,14 @@ class PetControllerV3
 
     server do
       key :url, "http://petstore.swagger.io/v1"
+      key :description, "Petstore API"
+    end
+
+    security do
+      key :ApiKeyAuth, []
+    end
+    security do
+      key :OAuth2, ["read", "write"]
     end
 
     tag do

--- a/spec/lib/swagger_v3_blocks_spec.rb
+++ b/spec/lib/swagger_v3_blocks_spec.rb
@@ -208,12 +208,7 @@ class PetControllerV3
         key :"$ref", :PetBody
       end
       response 200 do
-        key :description, 'Expected response to a valid request'
-        content :'application/json' do
-          schema do
-            key :'$ref', :Pet
-          end
-        end
+        key :'$ref', :ReplacePetBodyResponse
       end
       response :default do
         key :description, 'unexpected error'
@@ -428,6 +423,14 @@ class PetV3
     request_body :PetBody do
       key :description, 'A JSON object containing pet information'
       key :required, true
+      content :'application/json' do
+        schema do
+          key :'$ref', :Pet
+        end
+      end
+    end
+    response :ReplacePetBodyResponse do
+      key :description, 'Expected response to a valid request'
       content :'application/json' do
         schema do
           key :'$ref', :Pet

--- a/spec/lib/swagger_v3_blocks_spec.rb
+++ b/spec/lib/swagger_v3_blocks_spec.rb
@@ -225,6 +225,10 @@ class PetControllerV3
       end
     end
   end
+end
+
+class PetV3
+  include Swagger::Blocks
 
   swagger_path '/pets/{petId}/purchase' do
     operation :post do
@@ -291,11 +295,6 @@ class PetControllerV3
       end
     end
   end
-end
-
-class PetV3
-  include Swagger::Blocks
-
   swagger_component do
     schema :Pet, required: [:id, :name] do
       property :id do

--- a/spec/lib/swagger_v3_blocks_spec.rb
+++ b/spec/lib/swagger_v3_blocks_spec.rb
@@ -28,6 +28,19 @@ class PetControllerV3
       key :description, "Petstore API"
     end
 
+    server do
+      key :url, "https://{subdomain}.site.com/{version}"
+      key :description, "The main prod server"
+
+      variable :subdomain do
+        key :default, :production
+      end
+      variable :version do
+        key :enum, ["v1", "v2"]
+        key :default, :v2
+      end
+    end
+
     security do
       key :ApiKeyAuth, []
     end
@@ -104,13 +117,18 @@ class PetControllerV3
       key :tags, [
         'pets'
       ]
-      parameter do
-        key :name, :pet
-        key :in, :body
+      request_body do
         key :description, 'Pet to add to the store'
         key :required, true
-        schema do
-          key :'$ref', :PetInput
+        content "application/json" do
+          schema do
+            property :name do
+              key :type, :string
+            end
+            example do
+              key :name, "Fluffy"
+            end
+          end
         end
       end
       response 201 do
@@ -195,6 +213,10 @@ class PetControllerV3
         content "application/json" do
           schema do
             key :'$ref', "PetOrderRequest"
+          end
+          example do
+            key :id, 10
+            key :name, "Fluffy"
           end
         end
       end

--- a/spec/lib/swagger_v3_blocks_spec.rb
+++ b/spec/lib/swagger_v3_blocks_spec.rb
@@ -206,6 +206,27 @@ class PetControllerV3
         end
       end
     end
+    operation :post do
+      key :summary, 'Update info for a specific pet'
+      key :operationId, 'updatePetById'
+      key :tags, [
+        'pets'
+      ]
+      request_body do
+        key :"$ref", :PetBody
+      end
+      response 200 do
+        key :'$ref', :UpdatePetBodyResponse
+      end
+      response :default do
+        key :description, 'unexpected error'
+        content :'application/json' do
+          schema do
+            key :'$ref', :Error
+          end
+        end
+      end
+    end
     operation :put do
       key :summary, 'Replace info for a specific pet'
       key :operationId, 'replacePetById'
@@ -383,13 +404,6 @@ class PetV3
       end
       key :summary, "An example pet response"
     end
-    example :Cat do
-      value do
-        key :id, 1
-        key :name, "Felicity"
-      end
-      key :summary, "An example cat response"
-    end
     security_scheme :BasicAuth do
       key :type, :http
       key :scheme, :basic
@@ -406,18 +420,6 @@ class PetV3
     security_scheme :OpenID do
       key :type, :openIdConnect
       key :openIdConnectUrl, "https://example.com/.well-known/openid-configuration"
-    end
-    security_scheme :OAuth2 do
-      key :type, :oauth2
-      flow :authorizationCode do
-        key :authorizationUrl, "https://example.com/oauth/authorize"
-        key :tokenUrl, "https://example.com/oauth/token"
-        scopes do
-          key :read, "Grants read access"
-          key :write, "Grants write access"
-          key :admin, "Grants access to admin operations"
-        end
-      end
     end
     parameter :petId do
       key :name, :petId
@@ -465,13 +467,48 @@ class ErrorModelV3
   end
 end
 
+class AuxiliaryModelV3
+  include Swagger::Blocks
+
+  swagger_component do
+    response :UpdatePetBodyResponse do
+      key :description, 'Expected response to a valid request'
+      content :'application/json' do
+        schema do
+          key :'$ref', :Pet
+        end
+      end
+    end
+    example :Cat do
+      value do
+        key :id, 1
+        key :name, "Felicity"
+      end
+      key :summary, "An example cat response"
+    end
+    security_scheme :OAuth2 do
+      key :type, :oauth2
+      flow :authorizationCode do
+        key :authorizationUrl, "https://example.com/oauth/authorize"
+        key :tokenUrl, "https://example.com/oauth/token"
+        scopes do
+          key :read, "Grants read access"
+          key :write, "Grants write access"
+          key :admin, "Grants access to admin operations"
+        end
+      end
+    end
+  end
+end
+
 describe 'Swagger::Blocks v3' do
   describe 'build_json' do
     it 'outputs the correct data' do
       swaggered_classes = [
         PetControllerV3,
         PetV3,
-        ErrorModelV3
+        ErrorModelV3,
+        AuxiliaryModelV3
       ]
       actual = Swagger::Blocks.build_root_json(swaggered_classes)
       actual = JSON.parse(actual.to_json)  # For access consistency.
@@ -489,17 +526,20 @@ describe 'Swagger::Blocks v3' do
       expect(actual['components']).to eq(data['components'])
       expect(actual).to eq(data)
     end
+
     it 'is idempotent' do
-      swaggered_classes = [PetControllerV3, PetV3, ErrorModelV3]
+      swaggered_classes = [PetControllerV3, PetV3, ErrorModelV3, AuxiliaryModelV3]
       actual = JSON.parse(Swagger::Blocks.build_root_json(swaggered_classes).to_json)
       data = JSON.parse(RESOURCE_LISTING_JSON_V3)
       expect(actual).to eq(data)
     end
+
     it 'errors if no swagger_root is declared' do
       expect {
         Swagger::Blocks.build_root_json([])
       }.to raise_error(Swagger::Blocks::DeclarationError)
     end
+
     it 'errors if multiple swagger_roots are declared' do
       expect {
         Swagger::Blocks.build_root_json([PetControllerV3, PetControllerV3])


### PR DESCRIPTION
Adds support for PetStore OpenAPI 3 example.

Support for OpenAPI 3 is not feature complete.

## TODO
- Add support for callbacks ✅ 
- Add support for links [example](https://github.com/OAI/OpenAPI-Specification/blob/master/examples/v3.0/link-example.yaml) ✅ 
- Add support for examples [example](https://github.com/OAI/OpenAPI-Specification/blob/master/examples/v3.0/api-with-examples.yaml) ✅ 
- Add support for authentication schemes ✅ 
- Expand tests
