### PR TITLE
Concatenate actions under the same path but in different ruby classes/swagger blocks

### DIFF
--- a/lib/swagger/blocks/class_methods.rb
+++ b/lib/swagger/blocks/class_methods.rb
@@ -10,7 +10,7 @@ module Swagger
       end
 
       def version
-        if defined?(@swagger_root_node) && @swagger_root_node.data[:info] && @swagger_root_node.data[:info].version == '3.0.0'
+        if defined?(@swagger_root_node) && @swagger_root_node.data[:openapi] && @swagger_root_node.data[:openapi] == '3.0.0'
           '3.0.0'
         else
           '2.0'

--- a/lib/swagger/blocks/class_methods.rb
+++ b/lib/swagger/blocks/class_methods.rb
@@ -6,6 +6,7 @@ module Swagger
       # v2.0: Defines a Swagger Object
       # v2.0: https://github.com/swagger-api/swagger-spec/blob/master/versions/2.0.md#swagger-object
       def swagger_root(inline_keys = nil, &block)
+        # @@swagger_path_node_map = {}
         @swagger_root_node ||= Swagger::Blocks::Nodes::RootNode.call(inline_keys: inline_keys, &block)
       end
 
@@ -24,17 +25,18 @@ module Swagger
 
         # TODO enforce that path name begins with a '/'
         #   (or x- , but need to research Vendor Extensions first)
+        # puts "Pre - #{@@swagger_path_node_map.inspect}\n\n"
+        @swagger_path_node_map ||= {}
 
-        @@swagger_path_node_map ||= {}
-
-        path_node = @@swagger_path_node_map[path]
+        path_node = @swagger_path_node_map[path]
         if path_node
           # Merge this path declaration into the previous one
           path_node.instance_eval(&block)
         else
           # First time we've seen this path
-          @@swagger_path_node_map[path] = Swagger::Blocks::Nodes::PathNode.call(version: version, &block)
+          @swagger_path_node_map[path] = Swagger::Blocks::Nodes::PathNode.call(version: version, &block)
         end
+        # puts "Post - #{@@swagger_path_node_map.inspect}\n\n"
       end
 
       # v2.0: Defines a Swagger Definition Schema,
@@ -60,14 +62,14 @@ module Swagger
       def _swagger_nodes
         # Avoid initialization warnings.
         @swagger_root_node ||= nil
-        @@swagger_path_node_map ||= {}
+        @swagger_path_node_map ||= {}
         @swagger_schema_node_map ||= nil
         @swagger_api_root_node_map ||= {}
         @swagger_models_node ||= nil
         @swagger_components_node ||= nil
 
         data = {root_node: @swagger_root_node}
-        data[:path_node_map] = @@swagger_path_node_map
+        data[:path_node_map] = @swagger_path_node_map
         data[:schema_node_map] = @swagger_schema_node_map
         data[:api_node_map] = @swagger_api_root_node_map
         data[:models_node] = @swagger_models_node

--- a/lib/swagger/blocks/class_methods.rb
+++ b/lib/swagger/blocks/class_methods.rb
@@ -6,7 +6,6 @@ module Swagger
       # v2.0: Defines a Swagger Object
       # v2.0: https://github.com/swagger-api/swagger-spec/blob/master/versions/2.0.md#swagger-object
       def swagger_root(inline_keys = nil, &block)
-        # @@swagger_path_node_map = {}
         @swagger_root_node ||= Swagger::Blocks::Nodes::RootNode.call(inline_keys: inline_keys, &block)
       end
 
@@ -25,7 +24,6 @@ module Swagger
 
         # TODO enforce that path name begins with a '/'
         #   (or x- , but need to research Vendor Extensions first)
-        # puts "Pre - #{@@swagger_path_node_map.inspect}\n\n"
         @swagger_path_node_map ||= {}
 
         path_node = @swagger_path_node_map[path]
@@ -36,7 +34,6 @@ module Swagger
           # First time we've seen this path
           @swagger_path_node_map[path] = Swagger::Blocks::Nodes::PathNode.call(version: version, &block)
         end
-        # puts "Post - #{@@swagger_path_node_map.inspect}\n\n"
       end
 
       # v2.0: Defines a Swagger Definition Schema,

--- a/lib/swagger/blocks/class_methods.rb
+++ b/lib/swagger/blocks/class_methods.rb
@@ -25,15 +25,15 @@ module Swagger
         # TODO enforce that path name begins with a '/'
         #   (or x- , but need to research Vendor Extensions first)
 
-        @swagger_path_node_map ||= {}
+        @@swagger_path_node_map ||= {}
 
-        path_node = @swagger_path_node_map[path]
+        path_node = @@swagger_path_node_map[path]
         if path_node
           # Merge this path declaration into the previous one
           path_node.instance_eval(&block)
         else
           # First time we've seen this path
-          @swagger_path_node_map[path] = Swagger::Blocks::Nodes::PathNode.call(version: version, &block)
+          @@swagger_path_node_map[path] = Swagger::Blocks::Nodes::PathNode.call(version: version, &block)
         end
       end
 
@@ -60,14 +60,14 @@ module Swagger
       def _swagger_nodes
         # Avoid initialization warnings.
         @swagger_root_node ||= nil
-        @swagger_path_node_map ||= {}
+        @@swagger_path_node_map ||= {}
         @swagger_schema_node_map ||= nil
         @swagger_api_root_node_map ||= {}
         @swagger_models_node ||= nil
         @swagger_components_node ||= nil
 
         data = {root_node: @swagger_root_node}
-        data[:path_node_map] = @swagger_path_node_map
+        data[:path_node_map] = @@swagger_path_node_map
         data[:schema_node_map] = @swagger_schema_node_map
         data[:api_node_map] = @swagger_api_root_node_map
         data[:models_node] = @swagger_models_node

--- a/lib/swagger/blocks/internal_helpers.rb
+++ b/lib/swagger/blocks/internal_helpers.rb
@@ -20,7 +20,13 @@ module Swagger
 
           # 2.0
           if swagger_nodes[:path_node_map]
-            path_node_map.merge!(swagger_nodes[:path_node_map])
+            swagger_nodes[:path_node_map].each_key do |path|
+              if path_node_map.include?(path)
+                path_node_map[path].data.merge!(swagger_nodes[:path_node_map][path].data)
+              else
+                path_node_map[path] = swagger_nodes[:path_node_map][path]
+              end
+           end
           end
           if swagger_nodes[:schema_node_map]
             schema_node_map.merge!(swagger_nodes[:schema_node_map])


### PR DESCRIPTION
Currently, you cannot do this:
```
module API
    module V1
       module UsersController
           include Users::GetOne
           include Users::UpdateOne
           ...
       end
    end
end

module API
    module V1
       module Users
           module GetOne
               include Swagger::Blocks
               swagger_path "/api/v1/users/:id"
               ...
           end
       end
    end
end

module API
    module V1
       module Users
           module UpdateOne
               include Swagger::Blocks
               swagger_path "/api/v1/users/:id"
               ...
           end
       end
    end
end
```
The last swaggered class will be the only one to expose "/api/v1/users/:id".

Currently the cleanest way I found to allow it, but there might be better ways. Don't hesitate to comment.

EDIT: 
I also think there was an error in the version function. I'm pretty sure the open api version - or swagger - is meant to be in the `openapi`/`swagger` key while the `version` key under `info` is reserved for the api the documentation is for.