### PR TITLE
Add parent and data references to nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -452,6 +452,32 @@ operation :post do
 end
 ```
 
+Additionally, many APIs have standard responses based on the path or operation. You can retrieve references to these in order to DRY up code.
+
+```ruby
+module SwaggerResponses
+  module PostResponses
+    def self.extended(base)
+      operation = base.operation
+      path = base.parent.path
+
+      return unless operation == :post
+      base.response 201 do
+        key :description, dynamic_description_based_on_path
+        schema do
+          key :'$ref', dynamic_ref_name_based_on_path
+        end
+      end
+    end
+  end
+end
+
+operation :post do
+  extend SwaggerResponses::PostResponses
+  # ...
+end
+```
+
 ## Reference
 
 See the [swagger_v2_blocks_spec.rb](https://github.com/fotinakis/swagger-blocks/blob/master/spec/lib/swagger_v2_blocks_spec.rb) for examples of more complex features and declarations possible.

--- a/lib/swagger/blocks/class_methods.rb
+++ b/lib/swagger/blocks/class_methods.rb
@@ -33,7 +33,7 @@ module Swagger
           path_node.instance_eval(&block)
         else
           # First time we've seen this path
-          @swagger_path_node_map[path] = Swagger::Blocks::Nodes::PathNode.call(version: version, &block)
+          @swagger_path_node_map[path] = Swagger::Blocks::Nodes::PathNode.call(version: version, path: path.to_s, &block)
         end
       end
 

--- a/lib/swagger/blocks/node.rb
+++ b/lib/swagger/blocks/node.rb
@@ -2,17 +2,16 @@ module Swagger
   module Blocks
     # Base node for representing every object in the Swagger DSL.
     class Node
-      attr_accessor :name
+      attr_accessor :parent, :name
       attr_writer :version
       VERSION_2 = '2.0'
       VERSION_3 = '3.0.0'
 
-      def self.call(options = {}, &block)
+      def self.call(parent: nil, name: nil, version: nil, inline_keys: nil, &block)
         # Create a new instance and evaluate the block into it.
         instance = new
-        instance.name = options[:name] if options[:name]
-        instance.version = options[:version]
-        instance.keys options[:inline_keys]
+        instance.parent, instance.name, instance.version = parent, name, version
+        instance.keys inline_keys
         instance.instance_eval(&block) if block
         instance
       end

--- a/lib/swagger/blocks/node.rb
+++ b/lib/swagger/blocks/node.rb
@@ -7,7 +7,7 @@ module Swagger
       VERSION_2 = '2.0'
       VERSION_3 = '3.0.0'
 
-      def self.call(parent: nil, name: nil, version: nil, inline_keys: nil, &block)
+      def self.call(parent: nil, name: nil, version: nil, inline_keys: nil, **internal_data, &block)
         # Create a new instance and evaluate the block into it.
         instance = new
         instance.parent, instance.name, instance.version = parent, name, version

--- a/lib/swagger/blocks/nodes/all_of_node.rb
+++ b/lib/swagger/blocks/nodes/all_of_node.rb
@@ -35,7 +35,7 @@ module Swagger
         end
 
         def schema(inline_keys = nil, &block)
-          data << Swagger::Blocks::Nodes::SchemaNode.call(version: version, inline_keys: inline_keys, &block)
+          data << Swagger::Blocks::Nodes::SchemaNode.call(parent: self, version: version, inline_keys: inline_keys, &block)
         end
       end
     end

--- a/lib/swagger/blocks/nodes/callback_destination_node.rb
+++ b/lib/swagger/blocks/nodes/callback_destination_node.rb
@@ -3,7 +3,7 @@ module Swagger
     module Nodes
       class CallbackDestinationNode < Node
         def method(method_name, inline_keys = nil, &block)
-          self.data[method_name] = Swagger::Blocks::Nodes::CallbackMethodNode.call(version: version, inline_keys: inline_keys, &block)
+          self.data[method_name] = Swagger::Blocks::Nodes::CallbackMethodNode.call(parent: self, version: version, inline_keys: inline_keys, &block)
         end
       end
     end

--- a/lib/swagger/blocks/nodes/callback_method_node.rb
+++ b/lib/swagger/blocks/nodes/callback_method_node.rb
@@ -3,12 +3,12 @@ module Swagger
     module Nodes
       class CallbackMethodNode < Node
         def request_body(inline_keys = nil, &block)
-          self.data[:requestBody] = Swagger::Blocks::Nodes::RequestBodyNode.call(version: version, inline_keys: inline_keys, &block)
+          self.data[:requestBody] = Swagger::Blocks::Nodes::RequestBodyNode.call(parent: self, version: version, inline_keys: inline_keys, &block)
         end
 
         def response(resp, inline_keys = nil, &block)
           self.data[:responses] ||= {}
-          self.data[:responses][resp] = Swagger::Blocks::Nodes::ResponseNode.call(version: version, inline_keys: inline_keys, &block)
+          self.data[:responses][resp] = Swagger::Blocks::Nodes::ResponseNode.call(parent: self, version: version, inline_keys: inline_keys, &block)
         end
       end
     end

--- a/lib/swagger/blocks/nodes/callback_node.rb
+++ b/lib/swagger/blocks/nodes/callback_node.rb
@@ -3,7 +3,7 @@ module Swagger
     module Nodes
       class CallbackNode < Node
         def destination(address, inline_keys = nil, &block)
-          self.data[address] = Swagger::Blocks::Nodes::CallbackDestinationNode.call(version: version, inline_keys: inline_keys, &block)
+          self.data[address] = Swagger::Blocks::Nodes::CallbackDestinationNode.call(parent: self, version: version, inline_keys: inline_keys, &block)
         end
       end
     end

--- a/lib/swagger/blocks/nodes/component_node.rb
+++ b/lib/swagger/blocks/nodes/component_node.rb
@@ -11,38 +11,38 @@ module Swagger
             schema_node.instance_eval(&block)
           else
             # First time we've seen this schema_node
-            self.data[:schemas][name] = Swagger::Blocks::Nodes::SchemaNode.call(version: '3.0.0', inline_keys: inline_keys, &block)
+            self.data[:schemas][name] = Swagger::Blocks::Nodes::SchemaNode.call(parent: self, version: '3.0.0', inline_keys: inline_keys, &block)
           end
         end
 
         def link(name, inline_keys = nil, &block)
           self.data[:links] ||= {}
-          self.data[:links][name] = Swagger::Blocks::Nodes::LinkNode.call(version: version, inline_keys: inline_keys, &block)
+          self.data[:links][name] = Swagger::Blocks::Nodes::LinkNode.call(parent: self, version: version, inline_keys: inline_keys, &block)
         end
 
         def example(name, inline_keys = nil, &block)
           self.data[:examples] ||= {}
-          self.data[:examples][name] = Swagger::Blocks::Nodes::ExampleNode.call(version: version, inline_keys: inline_keys, &block)
+          self.data[:examples][name] = Swagger::Blocks::Nodes::ExampleNode.call(parent: self, version: version, inline_keys: inline_keys, &block)
         end
 
         def security_scheme(name, inline_keys = nil, &block)
           self.data[:securitySchemes] ||= {}
-          self.data[:securitySchemes][name] = Swagger::Blocks::Nodes::SecuritySchemeNode.call(version: version, inline_keys: inline_keys, &block)
+          self.data[:securitySchemes][name] = Swagger::Blocks::Nodes::SecuritySchemeNode.call(parent: self, version: version, inline_keys: inline_keys, &block)
         end
 
         def parameter(name, inline_keys = nil, &block)
           self.data[:parameters] ||= {}
-          self.data[:parameters][name] = Swagger::Blocks::Nodes::ParameterNode.call(version: version, inline_keys: inline_keys, &block)
+          self.data[:parameters][name] = Swagger::Blocks::Nodes::ParameterNode.call(parent: self, version: version, inline_keys: inline_keys, &block)
         end
 
         def request_body(name, inline_keys = nil, &block)
           self.data[:requestBodies] ||= {}
-          self.data[:requestBodies][name] = Swagger::Blocks::Nodes::RequestBodyNode.call(version: version, inline_keys: inline_keys, &block)
+          self.data[:requestBodies][name] = Swagger::Blocks::Nodes::RequestBodyNode.call(parent: self, version: version, inline_keys: inline_keys, &block)
         end
 
         def response(name, inline_keys = nil, &block)
           self.data[:responses] ||= {}
-          self.data[:responses][name] = Swagger::Blocks::Nodes::ResponseNode.call(version: version, inline_keys: inline_keys, &block)
+          self.data[:responses][name] = Swagger::Blocks::Nodes::ResponseNode.call(parent: self, version: version, inline_keys: inline_keys, &block)
         end
       end
     end

--- a/lib/swagger/blocks/nodes/content_node.rb
+++ b/lib/swagger/blocks/nodes/content_node.rb
@@ -3,15 +3,15 @@ module Swagger
     module Nodes
       class ContentNode < Node
         def schema(inline_keys = nil, &block)
-          self.data[:schema] = Swagger::Blocks::Nodes::SchemaNode.call(version: version, inline_keys: inline_keys, &block)
+          self.data[:schema] = Swagger::Blocks::Nodes::SchemaNode.call(parent: self, version: version, inline_keys: inline_keys, &block)
         end
 
         def example(name = nil, inline_keys = nil, &block)
           if name.nil?
-            self.data[:example] = Swagger::Blocks::Nodes::ExampleNode.call(version: version, inline_keys: inline_keys, &block)
+            self.data[:example] = Swagger::Blocks::Nodes::ExampleNode.call(parent: self, version: version, inline_keys: inline_keys, &block)
           else
             self.data[:examples] ||= {}
-            self.data[:examples][name] = Swagger::Blocks::Nodes::ExampleNode.call(version: version, inline_keys: inline_keys, &block)
+            self.data[:examples][name] = Swagger::Blocks::Nodes::ExampleNode.call(parent: self, version: version, inline_keys: inline_keys, &block)
           end
         end
       end

--- a/lib/swagger/blocks/nodes/example_node.rb
+++ b/lib/swagger/blocks/nodes/example_node.rb
@@ -3,7 +3,7 @@ module Swagger
     module Nodes
       class ExampleNode < Node
         def value(inline_keys = nil, &block)
-          self.data[:value] = Swagger::Blocks::Nodes::ValueNode.call(version: version, inline_keys: inline_keys, &block)
+          self.data[:value] = Swagger::Blocks::Nodes::ValueNode.call(parent: self, version: version, inline_keys: inline_keys, &block)
         end
       end
     end

--- a/lib/swagger/blocks/nodes/flow_node.rb
+++ b/lib/swagger/blocks/nodes/flow_node.rb
@@ -3,7 +3,7 @@ module Swagger
     module Nodes
       class FlowNode < Node
         def scopes(inline_keys = nil, &block)
-          self.data[:scopes] = Swagger::Blocks::Nodes::ScopesNode.call(version: version, inline_keys: inline_keys, &block)
+          self.data[:scopes] = Swagger::Blocks::Nodes::ScopesNode.call(parent: self, version: version, inline_keys: inline_keys, &block)
         end
       end
     end

--- a/lib/swagger/blocks/nodes/header_node.rb
+++ b/lib/swagger/blocks/nodes/header_node.rb
@@ -4,11 +4,11 @@ module Swagger
       # v2.0: https://github.com/swagger-api/swagger-spec/blob/master/versions/2.0.md#headerObject
       class HeaderNode < Node
         def items(inline_keys = nil, &block)
-          self.data[:items] = Swagger::Blocks::Nodes::ItemsNode.call(version: version, inline_keys: inline_keys, &block)
+          self.data[:items] = Swagger::Blocks::Nodes::ItemsNode.call(parent: self, version: version, inline_keys: inline_keys, &block)
         end
 
         def schema(inline_keys = nil, &block)
-          self.data[:schema] = Swagger::Blocks::Nodes::SchemaNode.call(version: version, inline_keys: inline_keys, &block)
+          self.data[:schema] = Swagger::Blocks::Nodes::SchemaNode.call(parent: self, version: version, inline_keys: inline_keys, &block)
         end
       end
     end

--- a/lib/swagger/blocks/nodes/info_node.rb
+++ b/lib/swagger/blocks/nodes/info_node.rb
@@ -4,11 +4,11 @@ module Swagger
       # v2.0: https://github.com/swagger-api/swagger-spec/blob/master/versions/2.0.md#infoObject
       class InfoNode < Node
         def contact(inline_keys = nil, &block)
-          self.data[:contact] = Swagger::Blocks::Nodes::ContactNode.call(version: version, inline_keys: inline_keys, &block)
+          self.data[:contact] = Swagger::Blocks::Nodes::ContactNode.call(parent: self, version: version, inline_keys: inline_keys, &block)
         end
 
         def license(inline_keys = nil, &block)
-          self.data[:license] = Swagger::Blocks::Nodes::LicenseNode.call(version: version, inline_keys: inline_keys, &block)
+          self.data[:license] = Swagger::Blocks::Nodes::LicenseNode.call(parent: self, version: version, inline_keys: inline_keys, &block)
         end
       end
     end

--- a/lib/swagger/blocks/nodes/items_node.rb
+++ b/lib/swagger/blocks/nodes/items_node.rb
@@ -10,7 +10,7 @@ module Swagger
         end
 
         def items(inline_keys = nil, &block)
-          self.data[:items] = Swagger::Blocks::Nodes::ItemsNode.call(version: version, inline_keys: inline_keys, &block)
+          self.data[:items] = Swagger::Blocks::Nodes::ItemsNode.call(parent: self, version: version, inline_keys: inline_keys, &block)
         end
       end
     end

--- a/lib/swagger/blocks/nodes/link_node.rb
+++ b/lib/swagger/blocks/nodes/link_node.rb
@@ -3,7 +3,7 @@ module Swagger
     module Nodes
       class LinkNode < Node
         def parameters(inline_keys = nil, &block)
-          self.data[:parameters] ||= Swagger::Blocks::Nodes::LinkParameterNode.call(version: version, inline_keys: inline_keys, &block)
+          self.data[:parameters] ||= Swagger::Blocks::Nodes::LinkParameterNode.call(parent: self, version: version, inline_keys: inline_keys, &block)
         end
       end
     end

--- a/lib/swagger/blocks/nodes/one_of_node.rb
+++ b/lib/swagger/blocks/nodes/one_of_node.rb
@@ -3,7 +3,7 @@ module Swagger
     module Nodes
       class OneOfNode < Node
         def items(inline_keys = nil, &block)
-          self.data[:items] = Swagger::Blocks::Nodes::ItemsNode.call(version: version, inline_keys: inline_keys, &block)
+          self.data[:items] = Swagger::Blocks::Nodes::ItemsNode.call(parent: self, version: version, inline_keys: inline_keys, &block)
         end
       end
     end

--- a/lib/swagger/blocks/nodes/operation_node.rb
+++ b/lib/swagger/blocks/nodes/operation_node.rb
@@ -7,37 +7,37 @@ module Swagger
           inline_keys = {'$ref' => "#/parameters/#{inline_keys}"} if inline_keys.is_a?(Symbol)
 
           self.data[:parameters] ||= []
-          self.data[:parameters] << Swagger::Blocks::Nodes::ParameterNode.call(version: version, inline_keys: inline_keys, &block)
+          self.data[:parameters] << Swagger::Blocks::Nodes::ParameterNode.call(parent: self, version: version, inline_keys: inline_keys, &block)
         end
 
         def response(resp, inline_keys = nil, &block)
           # TODO validate 'resp' is as per spec
           self.data[:responses] ||= {}
-          self.data[:responses][resp] = Swagger::Blocks::Nodes::ResponseNode.call(version: version, inline_keys: inline_keys, &block)
+          self.data[:responses][resp] = Swagger::Blocks::Nodes::ResponseNode.call(parent: self, version: version, inline_keys: inline_keys, &block)
         end
 
         def externalDocs(inline_keys = nil, &block)
-          self.data[:externalDocs] = Swagger::Blocks::Nodes::ExternalDocsNode.call(version: version, inline_keys: inline_keys, &block)
+          self.data[:externalDocs] = Swagger::Blocks::Nodes::ExternalDocsNode.call(parent: self, version: version, inline_keys: inline_keys, &block)
         end
 
         def security(inline_keys = nil, &block)
           self.data[:security] ||= []
-          self.data[:security] << Swagger::Blocks::Nodes::SecurityRequirementNode.call(version: version, inline_keys: inline_keys, &block)
+          self.data[:security] << Swagger::Blocks::Nodes::SecurityRequirementNode.call(parent: self, version: version, inline_keys: inline_keys, &block)
         end
 
         def request_body(inline_keys = nil, &block)
-          self.data[:requestBody] = Swagger::Blocks::Nodes::RequestBodyNode.call(version: version, inline_keys: inline_keys, &block)
+          self.data[:requestBody] = Swagger::Blocks::Nodes::RequestBodyNode.call(parent: self, version: version, inline_keys: inline_keys, &block)
         end
 
         def callback(event_name, inline_keys = nil, &block)
           self.data[:callbacks] ||= {}
-          self.data[:callbacks][event_name] = Swagger::Blocks::Nodes::CallbackNode.call(version: version, inline_keys: inline_keys, &block)
+          self.data[:callbacks][event_name] = Swagger::Blocks::Nodes::CallbackNode.call(parent: self, version: version, inline_keys: inline_keys, &block)
         end
 
         def server(inline_keys = nil, &block)
           raise NotSupportedError unless is_openapi_3_0?
           self.data[:servers] ||= []
-          self.data[:servers] << Swagger::Blocks::Nodes::ServerNode.call(version: version, inline_keys: inline_keys, &block)
+          self.data[:servers] << Swagger::Blocks::Nodes::ServerNode.call(parent: self, version: version, inline_keys: inline_keys, &block)
         end
       end
     end

--- a/lib/swagger/blocks/nodes/operation_node.rb
+++ b/lib/swagger/blocks/nodes/operation_node.rb
@@ -3,6 +3,14 @@ module Swagger
     module Nodes
       # v2.0: https://github.com/swagger-api/swagger-spec/blob/master/versions/2.0.md#operation-object
       class OperationNode < Node
+        attr_accessor :operation
+
+        def self.call(parent: nil, name: nil, version: nil, inline_keys: nil, **internal_data, &block)
+          instance = super
+          instance.operation = internal_data[:operation]
+          instance
+        end
+
         def parameter(inline_keys = nil, &block)
           inline_keys = {'$ref' => "#/parameters/#{inline_keys}"} if inline_keys.is_a?(Symbol)
 

--- a/lib/swagger/blocks/nodes/parameter_node.rb
+++ b/lib/swagger/blocks/nodes/parameter_node.rb
@@ -4,16 +4,16 @@ module Swagger
       # v2.0: https://github.com/swagger-api/swagger-spec/blob/master/versions/2.0.md#parameter-object
       class ParameterNode < Node
         def schema(inline_keys = nil, &block)
-          self.data[:schema] = Swagger::Blocks::Nodes::SchemaNode.call(version: version, inline_keys: inline_keys, &block)
+          self.data[:schema] = Swagger::Blocks::Nodes::SchemaNode.call(parent: self, version: version, inline_keys: inline_keys, &block)
         end
 
         def items(inline_keys = nil, &block)
-          self.data[:items] = Swagger::Blocks::Nodes::ItemsNode.call(version: version, inline_keys: inline_keys, &block)
+          self.data[:items] = Swagger::Blocks::Nodes::ItemsNode.call(parent: self, version: version, inline_keys: inline_keys, &block)
         end
 
         def example(name, inline_keys = nil, &block)
           self.data[:examples] ||= {}
-          self.data[:examples][name] = Swagger::Blocks::Nodes::ExampleNode.call(version: version, inline_keys: inline_keys, &block)
+          self.data[:examples][name] = Swagger::Blocks::Nodes::ExampleNode.call(parent: self, version: version, inline_keys: inline_keys, &block)
         end
       end
     end

--- a/lib/swagger/blocks/nodes/path_node.rb
+++ b/lib/swagger/blocks/nodes/path_node.rb
@@ -5,6 +5,14 @@ module Swagger
       class PathNode < Node
         OPERATION_TYPES = [:get, :put, :post, :delete, :options, :head, :patch].freeze
 
+        attr_accessor :path
+
+        def self.call(parent: nil, name: nil, version: nil, inline_keys: nil, **internal_data, &block)
+          instance = super
+          instance.path = internal_data[:path]
+          instance
+        end
+
         # TODO support ^x- Vendor Extensions
         def operation(op, inline_keys = nil, &block)
           op = op.to_sym

--- a/lib/swagger/blocks/nodes/path_node.rb
+++ b/lib/swagger/blocks/nodes/path_node.rb
@@ -17,7 +17,7 @@ module Swagger
         def operation(op, inline_keys = nil, &block)
           op = op.to_sym
           raise ArgumentError.new("#{name} not in #{OPERATION_TYPES}") if !OPERATION_TYPES.include?(op)
-          self.data[op] = Swagger::Blocks::Nodes::OperationNode.call(parent: self, version: version, inline_keys: inline_keys, &block)
+          self.data[op] = Swagger::Blocks::Nodes::OperationNode.call(parent: self, version: version, inline_keys: inline_keys, operation: op, &block)
         end
 
         def parameter(inline_keys = nil, &block)

--- a/lib/swagger/blocks/nodes/path_node.rb
+++ b/lib/swagger/blocks/nodes/path_node.rb
@@ -9,20 +9,20 @@ module Swagger
         def operation(op, inline_keys = nil, &block)
           op = op.to_sym
           raise ArgumentError.new("#{name} not in #{OPERATION_TYPES}") if !OPERATION_TYPES.include?(op)
-          self.data[op] = Swagger::Blocks::Nodes::OperationNode.call(version: version, inline_keys: inline_keys, &block)
+          self.data[op] = Swagger::Blocks::Nodes::OperationNode.call(parent: self, version: version, inline_keys: inline_keys, &block)
         end
 
         def parameter(inline_keys = nil, &block)
           inline_keys = {'$ref' => "#/parameters/#{inline_keys}"} if inline_keys.is_a?(Symbol)
 
           self.data[:parameters] ||= []
-          self.data[:parameters] << Swagger::Blocks::Nodes::ParameterNode.call(version: version, inline_keys: inline_keys, &block)
+          self.data[:parameters] << Swagger::Blocks::Nodes::ParameterNode.call(parent: self, version: version, inline_keys: inline_keys, &block)
         end
 
         def server(inline_keys = nil, &block)
           raise NotSupportedError unless is_openapi_3_0?
           self.data[:servers] ||= []
-          self.data[:servers] << Swagger::Blocks::Nodes::ServerNode.call(version: version, inline_keys: inline_keys, &block)
+          self.data[:servers] << Swagger::Blocks::Nodes::ServerNode.call(parent: self, version: version, inline_keys: inline_keys, &block)
         end
       end
     end

--- a/lib/swagger/blocks/nodes/properties_node.rb
+++ b/lib/swagger/blocks/nodes/properties_node.rb
@@ -3,7 +3,7 @@ module Swagger
     module Nodes
       class PropertiesNode < Node
         def property(name, inline_keys = nil, &block)
-          self.data[name] = Swagger::Blocks::Nodes::PropertyNode.call(version: version, inline_keys: inline_keys, &block)
+          self.data[name] = Swagger::Blocks::Nodes::PropertyNode.call(parent: self, version: version, inline_keys: inline_keys, &block)
         end
       end
     end

--- a/lib/swagger/blocks/nodes/property_node.rb
+++ b/lib/swagger/blocks/nodes/property_node.rb
@@ -3,7 +3,7 @@ module Swagger
     module Nodes
       class PropertyNode < Node
         def items(inline_keys = nil, &block)
-          self.data[:items] = Swagger::Blocks::Nodes::ItemsNode.call(version: version, inline_keys: inline_keys, &block)
+          self.data[:items] = Swagger::Blocks::Nodes::ItemsNode.call(parent: self, version: version, inline_keys: inline_keys, &block)
         end
 
         def property(name, inline_keys = nil, &block)
@@ -14,7 +14,7 @@ module Swagger
 
         def one_of(&block)
           self.data[:oneOf] ||= []
-          self.data[:oneOf] << Swagger::Blocks::Nodes::OneOfNode.call(version: version, &block)
+          self.data[:oneOf] << Swagger::Blocks::Nodes::OneOfNode.call(parent: self, version: version, &block)
         end
       end
     end

--- a/lib/swagger/blocks/nodes/request_body_node.rb
+++ b/lib/swagger/blocks/nodes/request_body_node.rb
@@ -4,7 +4,7 @@ module Swagger
       class RequestBodyNode < Node
         def content(type, inline_keys = nil, &block)
           self.data[:content] ||= {}
-          self.data[:content][type] = Swagger::Blocks::Nodes::ContentNode.call(version: version, inline_keys: inline_keys, &block)
+          self.data[:content][type] = Swagger::Blocks::Nodes::ContentNode.call(parent: self, version: version, inline_keys: inline_keys, &block)
         end
       end
     end

--- a/lib/swagger/blocks/nodes/response_node.rb
+++ b/lib/swagger/blocks/nodes/response_node.rb
@@ -4,32 +4,32 @@ module Swagger
       # v2.0: https://github.com/swagger-api/swagger-spec/blob/master/versions/2.0.md#responseObject
       class ResponseNode < Node
         def schema(inline_keys = nil, &block)
-          self.data[:schema] = Swagger::Blocks::Nodes::SchemaNode.call(version: version, inline_keys: inline_keys, &block)
+          self.data[:schema] = Swagger::Blocks::Nodes::SchemaNode.call(parent: self, version: version, inline_keys: inline_keys, &block)
         end
 
         def header(head, inline_keys = nil, &block)
           # TODO validate 'head' is as per spec
           self.data[:headers] ||= {}
-          self.data[:headers][head] = Swagger::Blocks::Nodes::HeaderNode.call(version: version, inline_keys: inline_keys, &block)
+          self.data[:headers][head] = Swagger::Blocks::Nodes::HeaderNode.call(parent: self, version: version, inline_keys: inline_keys, &block)
         end
 
         def content(type, inline_keys = nil, &block)
           self.data[:content] ||= {}
-          self.data[:content][type] = Swagger::Blocks::Nodes::ContentNode.call(version: version, inline_keys: inline_keys, &block)
+          self.data[:content][type] = Swagger::Blocks::Nodes::ContentNode.call(parent: self, version: version, inline_keys: inline_keys, &block)
         end
 
         def example(name = nil, inline_keys = nil, &block)
           if name.nil?
-            self.data[:example] = Swagger::Blocks::Nodes::ExampleNode.call(version: version, inline_keys: inline_keys, &block)
+            self.data[:example] = Swagger::Blocks::Nodes::ExampleNode.call(parent: self, version: version, inline_keys: inline_keys, &block)
           else
             self.data[:examples] ||= {}
-            self.data[:examples][name] = Swagger::Blocks::Nodes::ExampleNode.call(version: version, inline_keys: inline_keys, &block)
+            self.data[:examples][name] = Swagger::Blocks::Nodes::ExampleNode.call(parent: self, version: version, inline_keys: inline_keys, &block)
           end
         end
 
         def link(name, inline_keys = nil, &block)
           self.data[:links] ||= {}
-          self.data[:links][name] = Swagger::Blocks::Nodes::LinkNode.call(version: version, inline_keys: inline_keys, &block)
+          self.data[:links][name] = Swagger::Blocks::Nodes::LinkNode.call(parent: self, version: version, inline_keys: inline_keys, &block)
         end
       end
     end

--- a/lib/swagger/blocks/nodes/root_node.rb
+++ b/lib/swagger/blocks/nodes/root_node.rb
@@ -4,7 +4,7 @@ module Swagger
       class RootNode < Node
 
         def info(inline_keys = nil, &block)
-          self.data[:info] = Swagger::Blocks::Nodes::InfoNode.call(version: version, inline_keys: inline_keys, &block)
+          self.data[:info] = Swagger::Blocks::Nodes::InfoNode.call(parent: self, version: version, inline_keys: inline_keys, &block)
         end
 
         def parameter(param, inline_keys = nil, &block)
@@ -12,7 +12,7 @@ module Swagger
 
           # TODO validate 'param' is as per spec
           self.data[:parameters] ||= {}
-          self.data[:parameters][param] = Swagger::Blocks::Nodes::ParameterNode.call(version: version, inline_keys: inline_keys, &block)
+          self.data[:parameters][param] = Swagger::Blocks::Nodes::ParameterNode.call(parent: self, version: version, inline_keys: inline_keys, &block)
         end
 
         def response(resp, inline_keys = nil, &block)
@@ -20,46 +20,46 @@ module Swagger
 
           # TODO validate 'resp' is as per spec
           self.data[:responses] ||= {}
-          self.data[:responses][resp] = Swagger::Blocks::Nodes::ResponseNode.call(version: version, inline_keys: inline_keys, &block)
+          self.data[:responses][resp] = Swagger::Blocks::Nodes::ResponseNode.call(parent: self, version: version, inline_keys: inline_keys, &block)
         end
 
         def security_definition(name, inline_keys = nil, &block)
           raise NotSupportedError unless is_swagger_2_0?
 
           self.data[:securityDefinitions] ||= {}
-          self.data[:securityDefinitions][name] = Swagger::Blocks::Nodes::SecuritySchemeNode.call(version: version, inline_keys: inline_keys, &block)
+          self.data[:securityDefinitions][name] = Swagger::Blocks::Nodes::SecuritySchemeNode.call(parent: self, version: version, inline_keys: inline_keys, &block)
         end
 
         def security(inline_keys = nil, &block)
           raise NotSupportedError unless is_swagger_2_0? || is_openapi_3_0?
 
           self.data[:security] ||= []
-          self.data[:security] << Swagger::Blocks::Nodes::SecurityRequirementNode.call(version: version, inline_keys: inline_keys, &block)
+          self.data[:security] << Swagger::Blocks::Nodes::SecurityRequirementNode.call(parent: self, version: version, inline_keys: inline_keys, &block)
         end
 
         def externalDocs(inline_keys = nil, &block)
-          self.data[:externalDocs] = Swagger::Blocks::Nodes::ExternalDocsNode.call(version: version, inline_keys: inline_keys, &block)
+          self.data[:externalDocs] = Swagger::Blocks::Nodes::ExternalDocsNode.call(parent: self, version: version, inline_keys: inline_keys, &block)
         end
 
         def tag(inline_keys = nil, &block)
           raise NotSupportedError unless is_swagger_2_0? || is_openapi_3_0?
 
           self.data[:tags] ||= []
-          self.data[:tags] << Swagger::Blocks::Nodes::TagNode.call(version: version, inline_keys: inline_keys, &block)
+          self.data[:tags] << Swagger::Blocks::Nodes::TagNode.call(parent: self, version: version, inline_keys: inline_keys, &block)
         end
 
         def server(inline_keys = nil, &block)
           raise NotSupportedError unless is_openapi_3_0?
 
           self.data[:servers] ||= []
-          self.data[:servers] << Swagger::Blocks::Nodes::ServerNode.call(version: version, inline_keys: inline_keys, &block)
+          self.data[:servers] << Swagger::Blocks::Nodes::ServerNode.call(parent: self, version: version, inline_keys: inline_keys, &block)
         end
 
         def extension(name, inline_keys = nil, &block)
           raise NotSupportedError unless is_openapi_3_0?
 
           self.data[name] ||= []
-          self.data[name] << Swagger::Blocks::Nodes::VendorExtensionNode.call(version: version, inline_keys: inline_keys, &block)
+          self.data[name] << Swagger::Blocks::Nodes::VendorExtensionNode.call(parent: self, version: version, inline_keys: inline_keys, &block)
         end
 
         # Use 'tag' instead.

--- a/lib/swagger/blocks/nodes/schema_node.rb
+++ b/lib/swagger/blocks/nodes/schema_node.rb
@@ -4,11 +4,11 @@ module Swagger
       # v2.0: https://github.com/swagger-api/swagger-spec/blob/master/versions/2.0.md#schema-object
       class SchemaNode < Node
         def items(inline_keys = nil, &block)
-          self.data[:items] = Swagger::Blocks::Nodes::ItemsNode.call(version: version, inline_keys: inline_keys, &block)
+          self.data[:items] = Swagger::Blocks::Nodes::ItemsNode.call(parent: self, version: version, inline_keys: inline_keys, &block)
         end
 
         def allOf(&block)
-          self.data[:allOf] = Swagger::Blocks::Nodes::AllOfNode.call(version: version, &block)
+          self.data[:allOf] = Swagger::Blocks::Nodes::AllOfNode.call(parent: self, version: version, &block)
         end
 
         def property(name, inline_keys = nil, &block)
@@ -18,20 +18,20 @@ module Swagger
         end
 
         def xml(inline_keys = nil, &block)
-          self.data[:xml] = Swagger::Blocks::Nodes::XmlNode.call(version: version, inline_keys: inline_keys, &block)
+          self.data[:xml] = Swagger::Blocks::Nodes::XmlNode.call(parent: self, version: version, inline_keys: inline_keys, &block)
         end
 
         def externalDocs(inline_keys = nil, &block)
-          self.data[:externalDocs] = Swagger::Blocks::Nodes::ExternalDocsNode.call(version: version, inline_keys: inline_keys, &block)
+          self.data[:externalDocs] = Swagger::Blocks::Nodes::ExternalDocsNode.call(parent: self, version: version, inline_keys: inline_keys, &block)
         end
 
         def example(inline_keys = nil, &block)
-          self.data[:example] = Swagger::Blocks::Nodes::ExampleNode.call(version: version, inline_keys: inline_keys, &block)
+          self.data[:example] = Swagger::Blocks::Nodes::ExampleNode.call(parent: self, version: version, inline_keys: inline_keys, &block)
         end
 
         def one_of(&block)
           self.data[:oneOf] ||= []
-          self.data[:oneOf] << Swagger::Blocks::Nodes::OneOfNode.call(version: version, &block)
+          self.data[:oneOf] << Swagger::Blocks::Nodes::OneOfNode.call(parent: self, version: version, &block)
         end
       end
     end

--- a/lib/swagger/blocks/nodes/security_scheme_node.rb
+++ b/lib/swagger/blocks/nodes/security_scheme_node.rb
@@ -5,12 +5,12 @@ module Swagger
         # TODO support ^x- Vendor Extensions
 
         def scopes(inline_keys = nil, &block)
-          self.data[:scopes] = Swagger::Blocks::Nodes::ScopesNode.call(version: version, inline_keys: inline_keys, &block)
+          self.data[:scopes] = Swagger::Blocks::Nodes::ScopesNode.call(parent: self, version: version, inline_keys: inline_keys, &block)
         end
 
         def flow(name, inline_keys = nil, &block)
           self.data[:flows] ||= {}
-          self.data[:flows][name] = Swagger::Blocks::Nodes::FlowNode.call(version: version, inline_keys: inline_keys, &block)
+          self.data[:flows][name] = Swagger::Blocks::Nodes::FlowNode.call(parent: self, version: version, inline_keys: inline_keys, &block)
         end
       end
     end

--- a/lib/swagger/blocks/nodes/server_node.rb
+++ b/lib/swagger/blocks/nodes/server_node.rb
@@ -4,7 +4,7 @@ module Swagger
       class ServerNode < Node
         def variable(name, inline_keys = nil, &block)
           self.data[:variables] ||= {}
-          self.data[:variables][name] = Swagger::Blocks::Nodes::VariableNode.call(version: version, inline_keys: inline_keys, &block)
+          self.data[:variables][name] = Swagger::Blocks::Nodes::VariableNode.call(parent: self, version: version, inline_keys: inline_keys, &block)
         end
       end
     end

--- a/lib/swagger/blocks/nodes/tag_node.rb
+++ b/lib/swagger/blocks/nodes/tag_node.rb
@@ -7,7 +7,7 @@ module Swagger
         # TODO support ^x- Vendor Extensions
 
         def externalDocs(inline_keys = nil, &block)
-          self.data[:externalDocs] = Swagger::Blocks::Nodes::ExternalDocsNode.call(version: version, inline_keys: inline_keys, &block)
+          self.data[:externalDocs] = Swagger::Blocks::Nodes::ExternalDocsNode.call(parent: self, version: version, inline_keys: inline_keys, &block)
         end
       end
     end

--- a/spec/lib/class_methods_spec.rb
+++ b/spec/lib/class_methods_spec.rb
@@ -1,0 +1,17 @@
+require 'swagger/blocks'
+
+class PetController
+  include Swagger::Blocks
+
+  swagger_path '/pets'
+end
+
+describe 'ClassMethods' do
+  describe 'swagger_path' do
+    it 'creates a path node' do
+      path_map = PetController.instance_variable_get(:@swagger_path_node_map)
+      path_node = path_map[:'/pets']
+      expect(path_node.path).to eq('/pets')
+    end
+  end
+end

--- a/spec/lib/nodes/operation_node_spec.rb
+++ b/spec/lib/nodes/operation_node_spec.rb
@@ -1,0 +1,14 @@
+require 'swagger/blocks'
+
+describe 'OperationNode' do
+  describe 'call' do
+    it 'sets the operation' do
+      version, operation = '3.0.0', :get
+      operation_node = Swagger::Blocks::Nodes::OperationNode.call(version: version, operation: operation)
+
+      expect(operation_node).to be_a(Swagger::Blocks::Nodes::OperationNode)
+      expect(operation_node.operation).to eq(operation)
+      expect(operation_node.version).to eq(version)
+    end
+  end
+end

--- a/spec/lib/nodes/path_node_spec.rb
+++ b/spec/lib/nodes/path_node_spec.rb
@@ -1,0 +1,14 @@
+require 'swagger/blocks'
+
+describe 'PathNode' do
+  describe 'call' do
+    it 'sets the path' do
+      version, path = '3.0.0', '/pets'
+      path_node = Swagger::Blocks::Nodes::PathNode.call(version: version, path: path)
+
+      expect(path_node).to be_a(Swagger::Blocks::Nodes::PathNode)
+      expect(path_node.path).to eq(path)
+      expect(path_node.version).to eq(version)
+    end
+  end
+end

--- a/spec/lib/nodes/path_node_spec.rb
+++ b/spec/lib/nodes/path_node_spec.rb
@@ -11,4 +11,14 @@ describe 'PathNode' do
       expect(path_node.version).to eq(version)
     end
   end
+  describe 'operation' do
+    it 'creates an operation node' do
+      path_node = Swagger::Blocks::Nodes::PathNode.call(version: '3.0.0')
+      operation = :get
+      operation_node = path_node.operation(operation)
+
+      expect(operation_node).to be_a(Swagger::Blocks::Nodes::OperationNode)
+      expect(operation_node.operation).to eq(operation)
+    end
+  end
 end

--- a/spec/lib/nodes/root_node_spec.rb
+++ b/spec/lib/nodes/root_node_spec.rb
@@ -1,0 +1,13 @@
+require 'swagger/blocks'
+
+describe 'RootNode' do
+  describe 'build_json' do
+    it 'creates an info node' do
+      root_node = Swagger::Blocks::Nodes::RootNode.call(version: '3.0.0')
+      info_node = root_node.info
+
+      expect(info_node).to be_a(Swagger::Blocks::Nodes::InfoNode)
+      expect(info_node.parent).to eq(root_node)
+    end
+  end
+end


### PR DESCRIPTION
Adds references to parent node to all nodes. Adds references to the path for path nodes and to the operation for operation nodes in order to allow for dynamic parameter/response generation and reduce boilerplate.